### PR TITLE
Rename errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Naming?
 - [ ] ResponseParser -> Codecs?
 - [x] CreateResponse/GetResponse -> Add interfaces?
 - [ ] Parser -> parseXResponse => parse{Attestation|Assertion}Data
-- [ ] Error\* -> Errors\*
+- [x] Error\* -> Errors\*
 
 Nice to haves/Future scope:
 - [x] Refactor FIDO attestation to not need AD.getAttestedCredentialData
@@ -447,7 +447,7 @@ Similarly, for data storage, the output of `Codecs\Credential::encode()` are als
 The library is built around a "fail loudly" principle.
 During both the registration and authentication process, if an exception is not thrown it means that the process succeeded.
 Be prepared to catch and handle these exceptions.
-All exceptions thrown by the library implement `Firehed\WebAuthn\Error\WebAuthnErrorInterface`, so if you want to only catch library errors (or test for them in a generic error handler), use that interface.
+All exceptions thrown by the library implement `Firehed\WebAuthn\Errors\WebAuthnErrorInterface`, so if you want to only catch library errors (or test for them in a generic error handler), use that interface.
 
 ### Registration & Credential Storage
 

--- a/src/CreateResponse.php
+++ b/src/CreateResponse.php
@@ -38,7 +38,7 @@ class CreateResponse implements Responses\AttestationInterface
         // 7.1.6
         $C = json_decode($this->clientDataJson->unwrap(), true);
         if (!is_array($C)) {
-            throw new Error\ParseError('7.1.6', 'JSON decoding returned the wrong format');
+            throw new Errors\ParseError('7.1.6', 'JSON decoding returned the wrong format');
         }
 
         // 7.1.7
@@ -146,6 +146,6 @@ class CreateResponse implements Responses\AttestationInterface
 
     private function fail(string $section, string $desc): never
     {
-        throw new Error\RegistrationError($section, $desc);
+        throw new Errors\RegistrationError($section, $desc);
     }
 }

--- a/src/Errors/ParseError.php
+++ b/src/Errors/ParseError.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\WebAuthn\Error;
+namespace Firehed\WebAuthn\Errors;
 
 use UnexpectedValueException;
 

--- a/src/Errors/RegistrationError.php
+++ b/src/Errors/RegistrationError.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\WebAuthn\Error;
+namespace Firehed\WebAuthn\Errors;
 
 /**
  * Errors that can occur during Registring a New Credential

--- a/src/Errors/SecurityError.php
+++ b/src/Errors/SecurityError.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\WebAuthn\Error;
+namespace Firehed\WebAuthn\Errors;
 
 use RuntimeException;
 

--- a/src/Errors/VerificationError.php
+++ b/src/Errors/VerificationError.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\WebAuthn\Error;
+namespace Firehed\WebAuthn\Errors;
 
 /**
  * Errors that can occur during Verifying an Authentication Assertion

--- a/src/Errors/WebAuthnErrorInterface.php
+++ b/src/Errors/WebAuthnErrorInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\WebAuthn\Error;
+namespace Firehed\WebAuthn\Errors;
 
 use Throwable;
 

--- a/src/GetResponse.php
+++ b/src/GetResponse.php
@@ -74,7 +74,7 @@ class GetResponse implements Responses\AssertionInterface
         // 7.2.10
         $C = json_decode($JSONtext, true);
         if (!is_array($C)) {
-            throw new Error\ParseError('7.2.10', 'JSON decoding returned the wrong format');
+            throw new Errors\ParseError('7.2.10', 'JSON decoding returned the wrong format');
         }
 
         // 7.2.11
@@ -163,6 +163,6 @@ class GetResponse implements Responses\AssertionInterface
 
     private function fail(string $section, string $desc): never
     {
-        throw new Error\VerificationError($section, $desc);
+        throw new Errors\VerificationError($section, $desc);
     }
 }

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -52,16 +52,16 @@ class ResponseParser
     public function parseCreateResponse(array $response): Responses\AttestationInterface
     {
         if (!array_key_exists('type', $response) || $response['type'] !== 'public-key') {
-            throw new Error\ParseError('7.1.2', 'response.type');
+            throw new Errors\ParseError('7.1.2', 'response.type');
         }
         if (!array_key_exists('rawId', $response) || !is_array($response['rawId'])) {
-            throw new Error\ParseError('7.1.2', 'response.rawId');
+            throw new Errors\ParseError('7.1.2', 'response.rawId');
         }
         if (!array_key_exists('attestationObject', $response) || !is_array($response['attestationObject'])) {
-            throw new Error\ParseError('7.1.2', 'response.attestationObject');
+            throw new Errors\ParseError('7.1.2', 'response.attestationObject');
         }
         if (!array_key_exists('clientDataJSON', $response) || !is_array($response['clientDataJSON'])) {
-            throw new Error\ParseError('7.1.2', 'response.clientDataJSON');
+            throw new Errors\ParseError('7.1.2', 'response.clientDataJSON');
         }
         return new CreateResponse(
             id: BinaryString::fromBytes($response['rawId']),
@@ -103,19 +103,19 @@ class ResponseParser
     public function parseGetResponse(array $response): Responses\AssertionInterface
     {
         if (!array_key_exists('type', $response) || $response['type'] !== 'public-key') {
-            throw new Error\ParseError('7.2.2', 'response.type');
+            throw new Errors\ParseError('7.2.2', 'response.type');
         }
         if (!array_key_exists('rawId', $response) || !is_array($response['rawId'])) {
-            throw new Error\ParseError('7.2.2', 'response.rawId');
+            throw new Errors\ParseError('7.2.2', 'response.rawId');
         }
         if (!array_key_exists('authenticatorData', $response) || !is_array($response['authenticatorData'])) {
-            throw new Error\ParseError('7.2.2', 'response.authenticatorData');
+            throw new Errors\ParseError('7.2.2', 'response.authenticatorData');
         }
         if (!array_key_exists('clientDataJSON', $response) || !is_array($response['clientDataJSON'])) {
-            throw new Error\ParseError('7.2.2', 'response.clientDataJSON');
+            throw new Errors\ParseError('7.2.2', 'response.clientDataJSON');
         }
         if (!array_key_exists('signature', $response) || !is_array($response['signature'])) {
-            throw new Error\ParseError('7.2.2', 'response.signature');
+            throw new Errors\ParseError('7.2.2', 'response.signature');
         }
 
         // userHandle provides the user.id from registration

--- a/tests/CreateResponseTest.php
+++ b/tests/CreateResponseTest.php
@@ -317,7 +317,7 @@ class CreateResponseTest extends \PHPUnit\Framework\TestCase
 
     private function expectRegistrationError(string $section): void
     {
-        $this->expectException(Error\RegistrationError::class);
+        $this->expectException(Errors\RegistrationError::class);
         // TODO: how to assert on $section
     }
 }

--- a/tests/GetResponseTest.php
+++ b/tests/GetResponseTest.php
@@ -234,7 +234,7 @@ class GetResponseTest extends \PHPUnit\Framework\TestCase
 
     private function expectVerificationError(string $section): void
     {
-        $this->expectException(Error\VerificationError::class);
+        $this->expectException(Errors\VerificationError::class);
         // TODO: how to assert on $section
     }
 }


### PR DESCRIPTION
Ergonomically, most of the namespaces are plural; this change updates the various exceptions to match.