### PR TITLE
Add tests for pubkey formatting

### DIFF
--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -68,8 +68,8 @@ class EllipticCurve implements PublicKeyInterface
         $der .= $this->x->unwrap();
         $der .= $this->y->unwrap();
 
-        $pem  = "-----BEGIN PUBLIC KEY-----\r\n";
-        $pem .= chunk_split(base64_encode($der), 64);
+        $pem  = "-----BEGIN PUBLIC KEY-----\n";
+        $pem .= chunk_split(base64_encode($der), 64, "\n");
         $pem .= "-----END PUBLIC KEY-----";
         return $pem;
     }

--- a/tests/PublicKey/EllipticCurveTest.php
+++ b/tests/PublicKey/EllipticCurveTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\WebAuthn\PublicKey;
+
+use Firehed\WebAuthn\BinaryString;
+
+/**
+ * @covers Firehed\WebAuthn\PublicKey\EllipticCurve
+ */
+class EllipticCurveTest extends \PHPUnit\Framework\TestCase
+{
+    public function testFormatHandling(): void
+    {
+        // Generated a keypair with openssl:
+        //   openssl ecparam -name secp256r1 -genkey -noout -out pk.pem
+        //
+        // Get key info:
+        //   openssl ec -in pk.pem -text -noout
+        //
+        // Manually copied the output in the `pub:` section, removing the
+        // leading `04:` (which is a format indicator for uncompressed) and set
+        // into $x and $y below
+        //
+        // Extracted public key:
+        //    openssl ec -in pk.pem -pubout pub.pem
+        // and copied into $opensslPubKey
+
+        $x = BinaryString::fromHex('0f06777d44842cce4a2e7d00587b3fc892a7da7cf1704a8dd1ffb7e5334721a8');
+        $y = BinaryString::fromHex('3f017188437532409d6bbc86b68d56214a720bf8c183f844c576f4e2003ba976');
+
+        $pk = new EllipticCurve($x, $y);
+        self::assertSame($x->unwrap(), $pk->getXCoordinate(), 'X-coordinate changed');
+        self::assertSame($y->unwrap(), $pk->getYCoordinate(), 'Y-coordinate changed');
+
+        $opensslPubKey = <<<PEM
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDwZ3fUSELM5KLn0AWHs/yJKn2nzx
+        cEqN0f+35TNHIag/AXGIQ3UyQJ1rvIa2jVYhSnIL+MGD+ETFdvTiADupdg==
+        -----END PUBLIC KEY-----
+        PEM;
+
+        self::assertSame($opensslPubKey, $pk->getPemFormatted(), 'pubkey format changed');
+    }
+}


### PR DESCRIPTION
This also does an inconsequential tweak around line endings, which doesn't seem to impact any of the internal handling.