### PR TITLE
COSE Key parsing test

### DIFF
--- a/src/Attestations/FidoU2F.php
+++ b/src/Attestations/FidoU2F.php
@@ -65,8 +65,8 @@ class FidoU2F implements AttestationStatementInterface
         $publicKeyU2F = sprintf(
             '%s%s%s',
             "\x04",
-            $credentialPublicKey->getXCoordinate(),
-            $credentialPublicKey->getYCoordinate(),
+            $credentialPublicKey->getXCoordinate()->unwrap(),
+            $credentialPublicKey->getYCoordinate()->unwrap(),
         );
 
 

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -34,18 +34,18 @@ class EllipticCurve implements PublicKeyInterface
      * Returns a 32-byte string representing the 256-bit X-coordinate on the
      * curve
      */
-    public function getXCoordinate(): string
+    public function getXCoordinate(): BinaryString
     {
-        return $this->x->unwrap();
+        return $this->x;
     }
 
     /**
      * Returns a 32-byte string representing the 256-bit Y-coordinate on the
      * curve
      */
-    public function getYCoordinate(): string
+    public function getYCoordinate(): BinaryString
     {
-        return $this->y->unwrap();
+        return $this->y;
     }
 
     // Prepends the pubkey format headers and builds a pem file from the raw

--- a/tests/COSEKeyTest.php
+++ b/tests/COSEKeyTest.php
@@ -29,5 +29,6 @@ class COSEKeyTest extends \PHPUnit\Framework\TestCase
                 ->equals($pk->getYCoordinate()),
             'Y-coordinate wrong',
         );
+        // TODO: assert that it's a P256 key (see notes in EC class)
     }
 }

--- a/tests/COSEKeyTest.php
+++ b/tests/COSEKeyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\WebAuthn;
+
+/**
+ * @covers Firehed\WebAuthn\COSEKey
+ */
+class COSEKeyTest extends \PHPUnit\Framework\TestCase
+{
+    public function testKeyParsing(): void
+    {
+        $cbor = BinaryString::fromHex(
+            'a50102032620012158204c4c5bfc76bfc5cb1a51dc464c67f4cbecab779063c4' .
+            '540993bcc397e472b84b2258202964b35782fe6bc89d7c310a623f77e94dc2ef' .
+            'cdda936533cc93451ef6c39f71'
+        );
+        $coseKey = new COSEKey($cbor);
+        $pk = $coseKey->getPublicKey();
+        self::assertInstanceOf(PublicKey\EllipticCurve::class, $pk);
+        self::assertTrue(
+            BinaryString::fromHex('4c4c5bfc76bfc5cb1a51dc464c67f4cbecab779063c4540993bcc397e472b84b')
+                ->equals($pk->getXCoordinate()),
+            'X-coordinate wrong',
+        );
+        self::assertTrue(
+            BinaryString::fromHex('2964b35782fe6bc89d7c310a623f77e94dc2efcdda936533cc93451ef6c39f71')
+                ->equals($pk->getYCoordinate()),
+            'Y-coordinate wrong',
+        );
+    }
+}

--- a/tests/PublicKey/EllipticCurveTest.php
+++ b/tests/PublicKey/EllipticCurveTest.php
@@ -31,8 +31,8 @@ class EllipticCurveTest extends \PHPUnit\Framework\TestCase
         $y = BinaryString::fromHex('3f017188437532409d6bbc86b68d56214a720bf8c183f844c576f4e2003ba976');
 
         $pk = new EllipticCurve($x, $y);
-        self::assertSame($x->unwrap(), $pk->getXCoordinate(), 'X-coordinate changed');
-        self::assertSame($y->unwrap(), $pk->getYCoordinate(), 'Y-coordinate changed');
+        self::assertTrue($x->equals($pk->getXCoordinate()), 'X-coordinate changed');
+        self::assertTrue($y->equals($pk->getYCoordinate()), 'Y-coordinate changed');
 
         $opensslPubKey = <<<PEM
         -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
Adds a basic test that a COSE key is successfully parsed into the relevant data structures.

Future scope: try to import examples from https://github.com/cose-wg/Examples referenced in RFC8152 Appendix C.

Also consider separation of CBOR parsing from the constructor, in favor of being able to provide the resulting array directly?