### PR TITLE
Improve ergonomics of verify process

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Nice to haves/Future scope:
 - [ ] Permit changing the Relying Party ID
 - [ ] Refactor COSEKey to support other key types, use enums & ADT-style composition
 - [ ] GetResponse userHandle
+- [x] Assertion.verify (CredentialI | CredentialContainer)
 
 Testing:
 - [x] Happy path w/ FidoU2F

--- a/README.md
+++ b/README.md
@@ -308,17 +308,8 @@ $challenge = $_SESSION['webauthn_challenge'];
 
 $credentialContainer = getCredentialsForUserId($pdo, $_SESSION['authenticating_user_id']);
 
-$foundCredential = $credentialContainer->findCredentialUsedByResponse($getResponse);
-if ($foundCredential === null) {
-    // The credentials associated with the authenticating user did not match the
-    // one used in the response. If you are using allowCredentials (as above),
-    // this should never happen.
-    header('HTTP/1.1 403 Unauthorized');
-    return;
-}
-
 try {
-    $updatedCredential = $getResponse->verify($challenge, $rp, $foundCredential);
+    $updatedCredential = $getResponse->verify($challenge, $rp, $credentialContainer);
 } catch (Throwable) {
     // Verification failed. Send an error to the user?
     header('HTTP/1.1 403 Unauthorized');

--- a/examples/readmeLoginStep3.php
+++ b/examples/readmeLoginStep3.php
@@ -24,17 +24,8 @@ $challenge = $_SESSION['webauthn_challenge'];
 
 $credentialContainer = getCredentialsForUserId($pdo, $_SESSION['authenticating_user_id']);
 
-$foundCredential = $credentialContainer->findCredentialUsedByResponse($getResponse);
-if ($foundCredential === null) {
-    // The credentials associated with the authenticating user did not match the
-    // one used in the response. If you are using allowCredentials (as above),
-    // this should never happen.
-    header('HTTP/1.1 403 Unauthorized');
-    return;
-}
-
 try {
-    $updatedCredential = $getResponse->verify($challenge, $rp, $foundCredential);
+    $updatedCredential = $getResponse->verify($challenge, $rp, $credentialContainer);
 } catch (Throwable) {
     // Verification failed. Send an error to the user?
     header('HTTP/1.1 403 Unauthorized');
@@ -60,6 +51,5 @@ header('Content-type: application/json');
 echo json_encode([
     'success' => true,
     'user_id' => $_SESSION['authenticating_user_id'],
-    'credId' => $foundCredential->getStorageId(),
     'newCredId' => $updatedCredential->getStorageId(),
 ]);

--- a/src/GetResponse.php
+++ b/src/GetResponse.php
@@ -38,7 +38,7 @@ class GetResponse implements Responses\AssertionInterface
     public function verify(
         Challenge $challenge,
         RelyingParty $rp,
-        CredentialInterface $credential,
+        CredentialContainer | CredentialInterface $credential,
         UserVerificationRequirement $uv = UserVerificationRequirement::Preferred,
     ): CredentialInterface {
         // 7.2.1-7.2.4 are done in client side js & the ResponseParser
@@ -62,6 +62,12 @@ class GetResponse implements Responses\AssertionInterface
         // get credential from JS credential.id
         // (index into possible credential list?)
         // $credential is this value.
+        if ($credential instanceof CredentialContainer) {
+            $credential = $credential->findCredentialUsedByResponse($this);
+            if ($credential === null) {
+                $this->fail('7.2.7', 'Credential not found in container');
+            }
+        }
 
         // 7.2.8
         $cData = $this->clientDataJson->unwrap();

--- a/src/Responses/AssertionInterface.php
+++ b/src/Responses/AssertionInterface.php
@@ -7,6 +7,7 @@ namespace Firehed\WebAuthn\Responses;
 use Firehed\WebAuthn\{
     BinaryString,
     Challenge,
+    CredentialContainer,
     CredentialInterface,
     RelyingParty,
     UserVerificationRequirement,
@@ -31,7 +32,7 @@ interface AssertionInterface
     public function verify(
         Challenge $challenge,
         RelyingParty $rp,
-        CredentialInterface $credential,
+        CredentialContainer | CredentialInterface $credential,
         UserVerificationRequirement $uv = UserVerificationRequirement::Preferred,
     ): CredentialInterface;
 }


### PR DESCRIPTION
Rather than making the end-user handle 'credential used is not associated with the user' case, this allows the container as a whole to be passed into the assertion verification process to accomplish the same checks.