### PR TITLE
Refactor example code a bit

### DIFF
--- a/examples/getChallenge.php
+++ b/examples/getChallenge.php
@@ -1,0 +1,15 @@
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+session_start();
+
+// Generate challenge
+$challengeManager = getChallengeManager();
+$challenge = $challengeManager->createChallenge();
+
+// Send to user
+header('Content-type: application/json');
+echo json_encode([
+    'b64' => $challenge->getBase64(),
+]);

--- a/examples/readmeLoginStep1.php
+++ b/examples/readmeLoginStep1.php
@@ -14,12 +14,8 @@ $_SESSION['authenticating_user_id'] = $user['id'];
 
 $credentialContainer = getCredentialsForUserId($pdo, $user['id']);
 
-$challengeManager = getChallengeManager();
-$challenge = $challengeManager->createChallenge();
-
 // Send to user
 header('Content-type: application/json');
 echo json_encode([
-    'challengeB64' => $challenge->getBase64(),
     'credential_ids' => $credentialContainer->getBase64Ids(),
 ]);

--- a/examples/readmeLoginStep1.php
+++ b/examples/readmeLoginStep1.php
@@ -2,11 +2,6 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-use Firehed\WebAuthn\{
-    Codecs,
-    ExpiringChallenge,
-};
-
 session_start();
 
 $pdo = getDatabaseConnection();

--- a/examples/readmeLoginStep2.js
+++ b/examples/readmeLoginStep2.js
@@ -1,6 +1,9 @@
 const startLogin = async (e) => {
     e.preventDefault()
 
+    const challengeReq = await fetch('/getChallenge.php')
+    const challenge = await challengeReq.json()
+
     const username = document.getElementById('username').value
     const response = await fetch('/readmeLoginStep1.php', {
         method: 'POST',
@@ -14,7 +17,7 @@ const startLogin = async (e) => {
     // Format for WebAuthn API
     const getOptions = {
         publicKey: {
-            challenge: Uint8Array.from(atob(data.challengeB64), c => c.charCodeAt(0)),
+            challenge: Uint8Array.from(atob(challenge.b64), c => c.charCodeAt(0)),
             allowCredentials: data.credential_ids.map(id => ({
                 id: Uint8Array.from(atob(id), c => c.charCodeAt(0)),
                 type: 'public-key',

--- a/examples/readmeRegisterStep1.php
+++ b/examples/readmeRegisterStep1.php
@@ -2,8 +2,6 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-use Firehed\WebAuthn\ExpiringChallenge;
-
 session_start();
 
 // Normally this would come from something like a) a user already logged-in

--- a/examples/readmeRegisterStep1.php
+++ b/examples/readmeRegisterStep1.php
@@ -10,13 +10,8 @@ session_start();
 $user = createUser(getDatabaseConnection(), $_POST['username']);
 $_SESSION['user_id'] = $user['id'];
 
-// Generate challenge
-$challengeManager = getChallengeManager();
-$challenge = $challengeManager->createChallenge();
-
 // Send to user
 header('Content-type: application/json');
 echo json_encode([
-    'challengeB64' => $challenge->getBase64(),
     'user' => $user,
 ]);

--- a/examples/readmeRegisterStep2.js
+++ b/examples/readmeRegisterStep2.js
@@ -8,6 +8,9 @@ const startRegister = async (e) => {
         return
     }
 
+    const challengeReq = await fetch('/getChallenge.php')
+    const challenge = await challengeReq.json()
+
     const username = document.getElementById('username').value
 
     const response = await fetch('/readmeRegisterStep1.php', {
@@ -18,7 +21,6 @@ const startRegister = async (e) => {
         },
     })
     const responseData = await response.json()
-    const challenge = atob(responseData.challengeB64) // base64-decode
     const userInfo = responseData.user
 
     const createOptions = {
@@ -31,7 +33,9 @@ const startRegister = async (e) => {
                 displayName: 'User Name',
                 id: Uint8Array.from(userInfo.id, c => c.charCodeAt(0)),
             },
-            challenge: Uint8Array.from(challenge, c => c.charCodeAt(0)),
+            // This base64-decodes the response and translates it into the
+            // Webauthn-required format.
+            challenge: Uint8Array.from(atob(challenge.b64), c => c.charCodeAt(0)),
             pubKeyCredParams: [
                 {
                     alg: -7, // ES256


### PR DESCRIPTION
This updates the examples to split the challenge fetch into a separate endpoint, with the general intent that it could be more easily reused in a conditional mediation flow.