### PR TITLE
Improve logic matching key type to curve

### DIFF
--- a/src/COSEKey.php
+++ b/src/COSEKey.php
@@ -61,7 +61,17 @@ class COSEKey
         }
 
         $curve = COSE\Curve::tryFrom($decodedCbor[self::INDEX_CURVE]);
-        if ($curve !== COSE\Curve::P256) {
+        // https://www.w3.org/TR/webauthn-3/#sctn-alg-identifier
+        // 5.8.5 - curve must match algorithm
+        $expectedCurve = match ($algorithm) {
+            COSE\Algorithm::EcdsaSha256 => COSE\Curve::P256,
+            // Permit more later.
+            // COSE\Algorithm::EcdsaSha384 => COSE\Curve::P384,
+            // COSE\Algorithm::EcdsaSha512 => COSE\Curve::P521,
+            // COSE\Algorithm::EdDSA  => COSE\Curve::ED25519,
+        };
+
+        if ($curve !== $expectedCurve) {
             throw new DomainException('Only curve P-256 (secp256r1) supported');
         }
 


### PR DESCRIPTION
This improves adherence to the callout in [§5.8.5](https://www.w3.org/TR/webauthn-3/#sctn-alg-identifier). Note that the library still supports only ES256 with P-256. If a future version of the library supports additional key types and curves, this will be a more robust matching approach.