### PR TITLE
Add intermediate data structure for attested credential data

### DIFF
--- a/src/Attestations/FidoU2F.php
+++ b/src/Attestations/FidoU2F.php
@@ -55,9 +55,9 @@ class FidoU2F implements AttestationStatementInterface
 
         // 8.6.v.3
         $rpIdHash = $data->getRpIdHash();
-        $attestedCredential = $data->getAttestedCredential();
-        $credentialId = $attestedCredential->getId();
-        $credentialPublicKey = $attestedCredential->getPublicKey();
+        $attestedCredentialData = $data->getAttestedCredentialData();
+        $credentialId = $attestedCredentialData->credentialId;
+        $credentialPublicKey = $attestedCredentialData->coseKey->getPublicKey();
         assert($credentialPublicKey instanceof EllipticCurve);
 
         // 8.6.v.4

--- a/src/AttestedCredentialData.php
+++ b/src/AttestedCredentialData.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\WebAuthn;
+
+/**
+ * @internal
+ */
+class AttestedCredentialData
+{
+    public function __construct(
+        public readonly BinaryString $aaguid,
+        public readonly BinaryString $credentialId,
+        public readonly COSEKey $coseKey,
+    ) {
+    }
+}

--- a/src/CreateResponse.php
+++ b/src/CreateResponse.php
@@ -153,12 +153,17 @@ class CreateResponse implements Responses\AttestationInterface
         // 7.1.27
         // associate credential with new user
         // done in client code
-        $credential = $authData->getAttestedCredential();
+        $data = $authData->getAttestedCredentialData();
+        $credential = new Credential(
+            id: $this->id,
+            signCount: $authData->getSignCount(),
+            coseKey: $data->coseKey,
+        );
+
 
         // This is not part of the official procedure, but serves as a general
-        // sanity-check around data handling. It also silences an unused
-        // variable warning in PHPStan :)
-        assert($credential->getId()->equals($this->id));
+        // sanity-check around data handling.
+        assert($this->id->equals($data->credentialId));
 
         return $credential;
 

--- a/tests/Attestations/AttestationObjectTest.php
+++ b/tests/Attestations/AttestationObjectTest.php
@@ -140,7 +140,7 @@ class AttestationObjectTest extends \PHPUnit\Framework\TestCase
         );
         self::assertSame(0, $ad->getSignCount(), 'sign count');
 
-        $credential = $ad->getAttestedCredential();
+        $credential = $ad->getAttestedCredentialData();
         // TODO: check keypair?
     }
 

--- a/tests/AuthenticatorDataTest.php
+++ b/tests/AuthenticatorDataTest.php
@@ -29,7 +29,7 @@ class AuthenticatorDataTest extends \PHPUnit\Framework\TestCase
         self::assertTrue($ad->isUserVerified(), 'Flags bit 2 is set, UV=true');
         self::assertSame(0, $ad->getSignCount(), 'Sign count should be zero');
         try {
-            $_ = $ad->getAttestedCredential();
+            $_ = $ad->getAttestedCredentialData();
             self::fail('AuthData does not include an attested credential');
         } catch (\Throwable) {
         }
@@ -70,7 +70,7 @@ class AuthenticatorDataTest extends \PHPUnit\Framework\TestCase
         );
         self::assertTrue($ad->isUserPresent(), 'Flags bit 0 is set, UP=true');
         self::assertTrue($ad->isUserVerified(), 'Flags bit 2 is set, UV=true');
-        $_ = $ad->getAttestedCredential(); // Checking that this dones't throw.
+        $_ = $ad->getAttestedCredentialData(); // Checking that this doesn't throw.
     }
 
     public function testParseAssertionWithNoFlags(): void
@@ -93,7 +93,7 @@ class AuthenticatorDataTest extends \PHPUnit\Framework\TestCase
         self::assertFalse($ad->isUserVerified(), 'Flags bit 2 is not set, UV=false');
         self::assertSame(258, $ad->getSignCount(), 'Sign count wrong');
         try {
-            $_ = $ad->getAttestedCredential();
+            $_ = $ad->getAttestedCredentialData();
             self::fail('AuthData does not include an attested credential');
         } catch (\Throwable) {
         }


### PR DESCRIPTION
Rather than having the `AuthenticatorData` _build_ the Credential during registration, it's now being adjusted to instead return the underlying [components](https://www.w3.org/TR/webauthn-3/#sctn-attestation) that it will need.

While this is a minor structural formality right now, it will ease the adoption of the updated credential storage recommendations described in the Level 3 version of the spec that are not captured in the current L2-based implementation.