### PR TITLE
Version credentials

### DIFF
--- a/src/Codecs/Credential.php
+++ b/src/Codecs/Credential.php
@@ -7,7 +7,7 @@ namespace Firehed\WebAuthn\Codecs;
 use Firehed\WebAuthn\BinaryString;
 use Firehed\WebAuthn\COSEKey;
 use Firehed\WebAuthn\CredentialInterface;
-use Firehed\WebAuthn\Credential as CredentialObj;
+use Firehed\WebAuthn\CredentialV1;
 
 /**
  * This codec is responsible for serializing a CredentialInterface object to
@@ -113,7 +113,7 @@ class Credential
 
         $signCount = $bytes->readUint32();
 
-        return new CredentialObj(
+        return new CredentialV1(
             new BinaryString($id),
             new COSEKey(new BinaryString($cbor)),
             $signCount,

--- a/src/CreateResponse.php
+++ b/src/CreateResponse.php
@@ -154,7 +154,7 @@ class CreateResponse implements Responses\AttestationInterface
         // associate credential with new user
         // done in client code
         $data = $authData->getAttestedCredentialData();
-        $credential = new Credential(
+        $credential = new CredentialV1(
             id: $this->id,
             signCount: $authData->getSignCount(),
             coseKey: $data->coseKey,

--- a/src/CredentialV1.php
+++ b/src/CredentialV1.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Firehed\WebAuthn;
 
 /**
+ * Data format for WebAuthn Level 2 formats which lacked data for backup
+ * eligibility and did not track transports.
+ *
  * @internal
  */
-class Credential implements CredentialInterface
+class CredentialV1 implements CredentialInterface
 {
     // Risk factors:
     //   Create:

--- a/src/CredentialV1.php
+++ b/src/CredentialV1.php
@@ -52,10 +52,10 @@ class CredentialV1 implements CredentialInterface
 
     public function withUpdatedSignCount(int $newSignCount): CredentialInterface
     {
-        return new Credential(
-            $this->id,
-            $this->coseKey,
-            $newSignCount,
+        return new CredentialV1(
+            id: $this->id,
+            coseKey: $this->coseKey,
+            signCount: $newSignCount,
         );
     }
 }

--- a/tests/Codecs/CredentialTest.php
+++ b/tests/Codecs/CredentialTest.php
@@ -8,7 +8,7 @@ use Firehed\WebAuthn\{
     BinaryString,
     COSEKey,
     CredentialInterface,
-    Credential as CredentialObj,
+    CredentialV1,
 };
 
 /**
@@ -24,7 +24,7 @@ class CredentialTest extends \PHPUnit\Framework\TestCase
         $cbor = hex2bin($cborHex);
         assert($cbor !== false);
         $coseKey = new COSEKey(new BinaryString($cbor));
-        $credential = new CredentialObj(
+        $credential = new CredentialV1(
             new BinaryString(random_bytes(10)),
             $coseKey,
             15,

--- a/tests/CredentialV1Test.php
+++ b/tests/CredentialV1Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Firehed\WebAuthn;
 
 /**
- * @covers Firehed\WebAuthn\Credential
+ * @covers Firehed\WebAuthn\CredentialV1
  */
-class CredentialTest extends \PHPUnit\Framework\TestCase
+class CredentialV1Test extends \PHPUnit\Framework\TestCase
 {
     public function testAccessors(): void
     {
@@ -15,7 +15,7 @@ class CredentialTest extends \PHPUnit\Framework\TestCase
         $coseKey = self::createMock(COSEKey::class);
         $coseKey->method('getPublicKey')
             ->willReturn($pk);
-        $credential = new Credential(
+        $credential = new CredentialV1(
             id: BinaryString::fromHex('FFFF'),
             coseKey: $coseKey,
             signCount: 10,
@@ -36,7 +36,7 @@ class CredentialTest extends \PHPUnit\Framework\TestCase
         $coseKey = self::createMock(COSEKey::class);
         $coseKey->method('getPublicKey')
             ->willReturn($pk);
-        $credential = new Credential(
+        $credential = new CredentialV1(
             id: BinaryString::fromHex('0000'),
             coseKey: $coseKey,
             signCount: 20,


### PR DESCRIPTION
Renames `Credential` to `CredentialV1`, for the upcoming addition of `CredentialV2` which tracks additional data.

Extracted from #53.