### PR TITLE
Parse transports and pass them through to the credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ const dataForResponseParser = {
     type: credential.type,
     attestationObject: Array.from(new Uint8Array(credential.response.attestationObject)),
     clientDataJSON: Array.from(new Uint8Array(credential.response.clientDataJSON)),
+    transports: credential.response.getTransports(),
 }
 
 // Send this to your endpoint - adjust to your needs.

--- a/examples/readmeRegisterStep2.js
+++ b/examples/readmeRegisterStep2.js
@@ -58,6 +58,7 @@ const startRegister = async (e) => {
         type: credential.type,
         attestationObject: Array.from(new Uint8Array(credential.response.attestationObject)),
         clientDataJSON: Array.from(new Uint8Array(credential.response.clientDataJSON)),
+        transports: credential.response.getTransports(),
     }
 
     // Send this to your endpoint - adjust to your needs.

--- a/src/ArrayBufferResponseParser.php
+++ b/src/ArrayBufferResponseParser.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Firehed\WebAuthn;
 
+use function array_filter;
+use function array_key_exists;
+use function array_map;
+use function is_array;
+
 /**
  * Translates the library-official over-the-wire data formats into the
  * necessary data structures for subsequent authentication procedures.
@@ -70,7 +75,10 @@ class ArrayBufferResponseParser implements ResponseParserInterface
             throw new Errors\ParseError('7.1.2', 'response.clientDataJSON');
         }
 
-        $transports = array_filter(array_map(Enums\AuthenticatorTransport::tryFrom(...), $response['transports'] ?? []));
+        $transports = array_filter(array_map(
+            Enums\AuthenticatorTransport::tryFrom(...),
+            $response['transports'] ?? []
+        ));
 
         return new CreateResponse(
             id: BinaryString::fromBytes($response['rawId']),

--- a/src/ArrayBufferResponseParser.php
+++ b/src/ArrayBufferResponseParser.php
@@ -73,7 +73,6 @@ class ArrayBufferResponseParser implements ResponseParserInterface
         $transports = array_filter(array_map(Enums\AuthenticatorTransport::tryFrom(...), $response['transports'] ?? []));
 
         return new CreateResponse(
-            type: Enums\PublicKeyCredentialType::from($response['type']),
             id: BinaryString::fromBytes($response['rawId']),
             ao: Attestations\AttestationObject::fromCbor(BinaryString::fromBytes($response['attestationObject'])),
             clientDataJson: BinaryString::fromBytes($response['clientDataJSON']),

--- a/src/CreateResponse.php
+++ b/src/CreateResponse.php
@@ -22,7 +22,6 @@ class CreateResponse implements Responses\AttestationInterface
      * @param Enums\AuthenticatorTransport[] $transports
      */
     public function __construct(
-        private Enums\PublicKeyCredentialType $type,
         private BinaryString $id,
         private Attestations\AttestationObjectInterface $ao,
         private BinaryString $clientDataJson,
@@ -159,19 +158,13 @@ class CreateResponse implements Responses\AttestationInterface
         // (done in client code?)
 
         // 7.1.27
-        // Create and store credential and associate with user. Storage to be
-        // done in consuming code.
+        // associate credential with new user
+        // done in client code
         $data = $authData->getAttestedCredentialData();
-        $credential = new CredentialV2(
-            type: $this->type,
-            id: $this->id, // data->id?
+        $credential = new CredentialV1(
+            id: $this->id,
             signCount: $authData->getSignCount(),
             coseKey: $data->coseKey,
-            isUvInitialized: $authData->isUserVerified(),
-            transports: $this->transports,
-            isBackupEligible: $authData->isBackupEligible(),
-            isBackedUp: $authData->isBackedUp(),
-            // AO, CDJ
         );
 
         // This is not part of the official procedure, but serves as a general

--- a/src/JsonResponseParser.php
+++ b/src/JsonResponseParser.php
@@ -68,12 +68,20 @@ class JsonResponseParser implements ResponseParserInterface
         if (!array_key_exists('clientDataJSON', $response) || !is_string($response['clientDataJSON'])) {
             throw new Errors\ParseError('7.1.2', 'response.clientDataJSON');
         }
+        if (!array_key_exists('transports', $response) || !is_array($response['transports'])) {
+            throw new Errors\ParseError('7.1.2', 'transports');
+        }
+        // "client platforms MUST ignore unknown values" -> tryFrom+filter
+        $transports = array_filter(array_map(Enums\AuthenticatorTransport::tryFrom(...), $response['transports']));
+
         return new CreateResponse(
+            type: Enums\PublicKeyCredentialType::from($data['type']),
             id: self::parse($data['rawId'], '7.1.2', 'rawId'),
             ao: Attestations\AttestationObject::fromCbor(
                 self::parse($response['attestationObject'], '7.1.2', 'response.attestationObject'),
             ),
             clientDataJson: self::parse($response['clientDataJSON'], '7.1.2', 'response.clientDataJSON'),
+            transports: $transports,
         );
     }
 

--- a/src/JsonResponseParser.php
+++ b/src/JsonResponseParser.php
@@ -69,7 +69,7 @@ class JsonResponseParser implements ResponseParserInterface
             throw new Errors\ParseError('7.1.2', 'response.clientDataJSON');
         }
         if (!array_key_exists('transports', $response) || !is_array($response['transports'])) {
-            throw new Errors\ParseError('7.1.2', 'transports');
+            throw new Errors\ParseError('7.1.2', 'response.transports');
         }
         // "client platforms MUST ignore unknown values" -> tryFrom+filter
         $transports = array_filter(array_map(Enums\AuthenticatorTransport::tryFrom(...), $response['transports']));

--- a/src/JsonResponseParser.php
+++ b/src/JsonResponseParser.php
@@ -75,7 +75,6 @@ class JsonResponseParser implements ResponseParserInterface
         $transports = array_filter(array_map(Enums\AuthenticatorTransport::tryFrom(...), $response['transports']));
 
         return new CreateResponse(
-            type: Enums\PublicKeyCredentialType::from($data['type']),
             id: self::parse($data['rawId'], '7.1.2', 'rawId'),
             ao: Attestations\AttestationObject::fromCbor(
                 self::parse($response['attestationObject'], '7.1.2', 'response.attestationObject'),

--- a/tests/ArrayBufferResponseParserTest.php
+++ b/tests/ArrayBufferResponseParserTest.php
@@ -23,6 +23,31 @@ class ArrayBufferResponseParserTest extends \PHPUnit\Framework\TestCase
         self::assertInstanceOf(CreateResponse::class, $attestation);
     }
 
+    public function testParseCreateResponseWithTransports(): void
+    {
+        $response = $this->readFixture('touchid/register.json');
+        $response['transports'] = ['internal', 'hybrid'];
+
+        $parser = new ArrayBufferResponseParser();
+        $parsed = $parser->parseCreateResponse($response);
+        self::assertEqualsCanonicalizing([
+            Enums\AuthenticatorTransport::Hybrid,
+            Enums\AuthenticatorTransport::Internal,
+        ], $parsed->transports); // @phpstan-ignore-line (interface/impl cheat)
+    }
+
+    public function testParseCreateResponseWithInvalidTransports(): void
+    {
+        $response = $this->readFixture('touchid/register.json');
+        $response['transports'] = ['invalid', 'usb'];
+
+        $parser = new ArrayBufferResponseParser();
+        $parsed = $parser->parseCreateResponse($response);
+        self::assertEqualsCanonicalizing([
+            Enums\AuthenticatorTransport::Usb,
+        ], $parsed->transports); // @phpstan-ignore-line (interface/impl cheat)
+    }
+
     /**
      * @dataProvider badCreateResponses
      * @param mixed[] $response

--- a/tests/CreateResponseTest.php
+++ b/tests/CreateResponseTest.php
@@ -188,7 +188,6 @@ class CreateResponseTest extends \PHPUnit\Framework\TestCase
         $newCdj = new BinaryString(json_encode($cdj, JSON_THROW_ON_ERROR));
 
         $response = new CreateResponse(
-            type: Enums\PublicKeyCredentialType::PublicKey,
             id: $this->id,
             ao: $this->attestationObject,
             clientDataJson: $newCdj,
@@ -219,7 +218,6 @@ class CreateResponseTest extends \PHPUnit\Framework\TestCase
         $newCdj = new BinaryString(json_encode($cdj, JSON_THROW_ON_ERROR));
 
         $response = new CreateResponse(
-            type: Enums\PublicKeyCredentialType::PublicKey,
             id: $this->id,
             ao: $this->attestationObject,
             clientDataJson: $newCdj,
@@ -239,7 +237,6 @@ class CreateResponseTest extends \PHPUnit\Framework\TestCase
         $newCdj = new BinaryString(json_encode($cdj, JSON_THROW_ON_ERROR));
 
         $response = new CreateResponse(
-            type: Enums\PublicKeyCredentialType::PublicKey,
             id: $this->id,
             ao: $this->attestationObject,
             clientDataJson: $newCdj,
@@ -309,7 +306,6 @@ class CreateResponseTest extends \PHPUnit\Framework\TestCase
         ;
 
         $response = new CreateResponse(
-            type: Enums\PublicKeyCredentialType::PublicKey,
             id: $this->id,
             ao: $ao,
             clientDataJson: $this->clientDataJson,
@@ -327,30 +323,6 @@ class CreateResponseTest extends \PHPUnit\Framework\TestCase
         // Look for a specific id and public key?
     }
 
-    public function testTransportsEndUpInCredential(): void
-    {
-        $response = new CreateResponse(
-            type: Enums\PublicKeyCredentialType::PublicKey,
-            id: $this->id,
-            ao: $this->attestationObject,
-            clientDataJson: $this->clientDataJson,
-            transports: [
-                Enums\AuthenticatorTransport::Usb,
-                Enums\AuthenticatorTransport::Internal,
-                Enums\AuthenticatorTransport::Ble,
-                Enums\AuthenticatorTransport::SmartCard,
-            ],
-        );
-
-        $cred = $response->verify($this->cm, $this->rp);
-        self::assertEqualsCanonicalizing([
-            Enums\AuthenticatorTransport::Ble,
-            Enums\AuthenticatorTransport::Internal,
-            Enums\AuthenticatorTransport::SmartCard,
-            Enums\AuthenticatorTransport::Usb,
-        ], $cred->getTransports());
-    }
-
     private function expectRegistrationError(string $section): void
     {
         $this->expectException(Errors\RegistrationError::class);
@@ -360,7 +332,6 @@ class CreateResponseTest extends \PHPUnit\Framework\TestCase
     private function getDefaultResponse(): CreateResponse
     {
         return new CreateResponse(
-            type: Enums\PublicKeyCredentialType::PublicKey,
             id: $this->id,
             ao: $this->attestationObject,
             clientDataJson: $this->clientDataJson,

--- a/tests/JsonResponseParserTest.php
+++ b/tests/JsonResponseParserTest.php
@@ -37,7 +37,7 @@ class JsonResponseParserTest extends \PHPUnit\Framework\TestCase
     public function testParseCreateResponseWithInvalidTransports(): void
     {
         $response = $this->readFixture('safari-passkey-polyfill/register.json');
-        $response['response']['transports'] = ['invalid', 'usb'];
+        $response['response']['transports'] = ['invalid', 'usb']; // @phpstan-ignore-line
 
         $parser = new JsonResponseParser();
         $parsed = $parser->parseCreateResponse($response);

--- a/tests/JsonResponseParserTest.php
+++ b/tests/JsonResponseParserTest.php
@@ -121,6 +121,7 @@ class JsonResponseParserTest extends \PHPUnit\Framework\TestCase
             'invalid attestationObject' => $makeVector(['response' => ['attestationObject' => 'not base 64']]),
             'no clientDataJSON' => $makeVector(['response' => ['clientDataJSON' => null]]),
             'invalid clientDataJSON' => $makeVector(['response' => ['clientDataJSON' => 'not base 64']]),
+            'no transports' => $makeVector(['response' => ['transports' => null]]),
         ];
     }
 

--- a/tests/JsonResponseParserTest.php
+++ b/tests/JsonResponseParserTest.php
@@ -34,6 +34,18 @@ class JsonResponseParserTest extends \PHPUnit\Framework\TestCase
         $parser->parseCreateResponse($response);
     }
 
+    public function testParseCreateResponseWithInvalidTransports(): void
+    {
+        $response = $this->readFixture('safari-passkey-polyfill/register.json');
+        $response['response']['transports'] = ['invalid', 'usb'];
+
+        $parser = new JsonResponseParser();
+        $parsed = $parser->parseCreateResponse($response);
+        self::assertEqualsCanonicalizing([
+            Enums\AuthenticatorTransport::Usb,
+        ], $parsed->transports); // @phpstan-ignore-line (interface/impl cheat)
+    }
+
     /**
      * @dataProvider badGetResponses
      * @param mixed[] $response


### PR DESCRIPTION
Pulled out of #53 - it's desirable to store the transports alongside the credential in order to present future UI hints (note: it's not trusted data). Since that PR was getting pretty large, that aspect is being split out for readability.

Note: this maintains complete backwards compatibility with the original wire format, but does add a new recommendation to start passing the transports through.