### PR TITLE
Retain original CBOR for AttestationObject

### DIFF
--- a/src/ArrayBufferResponseParser.php
+++ b/src/ArrayBufferResponseParser.php
@@ -82,7 +82,7 @@ class ArrayBufferResponseParser implements ResponseParserInterface
 
         return new CreateResponse(
             id: BinaryString::fromBytes($response['rawId']),
-            ao: Attestations\AttestationObject::fromCbor(BinaryString::fromBytes($response['attestationObject'])),
+            ao: new Attestations\AttestationObject(BinaryString::fromBytes($response['attestationObject'])),
             clientDataJson: BinaryString::fromBytes($response['clientDataJSON']),
             transports: $transports,
         );

--- a/src/Attestations/AttestationObject.php
+++ b/src/Attestations/AttestationObject.php
@@ -16,16 +16,14 @@ use Firehed\WebAuthn\BinaryString;
  */
 class AttestationObject implements AttestationObjectInterface
 {
-    private function __construct(
-        private readonly AuthenticatorData $data,
-        private readonly AttestationStatementInterface $stmt,
-    ) {
-    }
+    private readonly AuthenticatorData $data;
+    private readonly AttestationStatementInterface $stmt;
 
-    public static function fromCbor(BinaryString $cbor): AttestationObject
-    {
+    public function __construct(
+        private readonly BinaryString $rawCbor,
+    ) {
         $decoder = new Decoder();
-        $decoded = $decoder->decode($cbor->unwrap());
+        $decoded = $decoder->decode($rawCbor->unwrap());
 
         assert(array_key_exists('fmt', $decoded));
         assert(array_key_exists('attStmt', $decoded));
@@ -38,7 +36,8 @@ class AttestationObject implements AttestationObjectInterface
 
         $ad = AuthenticatorData::parse(new BinaryString($decoded['authData']));
 
-        return new AttestationObject($ad, $stmt);
+        $this->data = $ad;
+        $this->stmt = $stmt;
     }
 
     public function getAuthenticatorData(): AuthenticatorData
@@ -52,5 +51,10 @@ class AttestationObject implements AttestationObjectInterface
     public function verify(BinaryString $clientDataHash): VerificationResult
     {
         return $this->stmt->verify($this->data, $clientDataHash);
+    }
+
+    public function getCbor(): BinaryString
+    {
+        return $this->rawCbor;
     }
 }

--- a/src/JsonResponseParser.php
+++ b/src/JsonResponseParser.php
@@ -76,7 +76,7 @@ class JsonResponseParser implements ResponseParserInterface
 
         return new CreateResponse(
             id: self::parse($data['rawId'], '7.1.2', 'rawId'),
-            ao: Attestations\AttestationObject::fromCbor(
+            ao: new Attestations\AttestationObject(
                 self::parse($response['attestationObject'], '7.1.2', 'response.attestationObject'),
             ),
             clientDataJson: self::parse($response['clientDataJSON'], '7.1.2', 'response.clientDataJSON'),

--- a/tests/Attestations/AttestationObjectTest.php
+++ b/tests/Attestations/AttestationObjectTest.php
@@ -125,7 +125,7 @@ class AttestationObjectTest extends \PHPUnit\Framework\TestCase
             218, 147, 101, 51, 204, 147, 69, 30,
             246, 195, 159, 113,
         ]);
-        $ao = AttestationObject::fromCbor($cbor);
+        $ao = new AttestationObject($cbor);
 
         // These assertions are slightly superficial, but it does serve as an
         // integration test that the data threads through.

--- a/tests/Attestations/AttestationObjectTest.php
+++ b/tests/Attestations/AttestationObjectTest.php
@@ -127,6 +127,7 @@ class AttestationObjectTest extends \PHPUnit\Framework\TestCase
         ]);
         $ao = new AttestationObject($cbor);
 
+        self::assertTrue($cbor->equals($ao->getCbor()));
         // These assertions are slightly superficial, but it does serve as an
         // integration test that the data threads through.
 

--- a/tests/CreateResponseTest.php
+++ b/tests/CreateResponseTest.php
@@ -145,7 +145,7 @@ class CreateResponseTest extends \PHPUnit\Framework\TestCase
             218, 147, 101, 51, 204, 147, 69, 30,
             246, 195, 159, 113,
         ]);
-        $this->attestationObject = Attestations\AttestationObject::fromCbor($aoData);
+        $this->attestationObject = new Attestations\AttestationObject($aoData);
 
         $this->clientDataJson = BinaryString::fromBytes([
             123, 34, 116, 121, 112, 101, 34, 58,


### PR DESCRIPTION
This is being pulled out of #53 to ease the storage of the attestation object without having to reinvent any data formats. Unused at this time.