### PR TITLE
Prep credential storage v2

### DIFF
--- a/src/CredentialInterface.php
+++ b/src/CredentialInterface.php
@@ -48,6 +48,9 @@ interface CredentialInterface
     public function getTransports(): array;
 
     /**
+     * Returns (optionally) an AttestationObject and the raw ClientDataJSON
+     * that was signed by that attestation. These are always used as a pair.
+     *
      * @return ?array{Attestations\AttestationObjectInterface, BinaryString}
      */
     public function getAttestationData(): ?array;

--- a/src/CredentialInterface.php
+++ b/src/CredentialInterface.php
@@ -41,8 +41,24 @@ interface CredentialInterface
      */
     public function getPublicKey(): PublicKey\PublicKeyInterface;
 
+    public function isBackupEligible(): bool;
+    public function isBackedUp(): bool;
+    public function isUvInitialized(): bool;
+    /** @return Enums\AuthenticatorTransport[] */
+    public function getTransports(): array;
+
+    /**
+     * @return ?array{Attestations\AttestationObjectInterface, BinaryString}
+     */
+    public function getAttestationData(): ?array;
+
+
     /**
      * @internal
      */
     public function withUpdatedSignCount(int $newSignCount): CredentialInterface;
+    // add:
+    // - withUvInitialized(bool)
+    // - withAttestation(AO, attCDJ)
+    // - withBackupState(bool)
 }

--- a/src/CredentialInterface.php
+++ b/src/CredentialInterface.php
@@ -12,17 +12,14 @@ namespace Firehed\WebAuthn;
 interface CredentialInterface
 {
     /**
-     * @api
+     * Returns (optionally) an AttestationObject and the raw ClientDataJSON
+     * that was signed by that attestation. These are always used as a pair.
      *
-     * Returns an encoded version of the credential's id guaranteed to return
-     * no binary characters.
-     */
-    public function getStorageId(): string;
-
-    /**
      * @internal
+     *
+     * @return ?array{Attestations\AttestationObjectInterface, BinaryString}
      */
-    public function getId(): BinaryString;
+    public function getAttestationData(): ?array;
 
     /**
      * @internal
@@ -34,27 +31,47 @@ interface CredentialInterface
     /**
      * @internal
      */
-    public function getSignCount(): int;
+    public function getId(): BinaryString;
 
     /**
      * @internal
      */
     public function getPublicKey(): PublicKey\PublicKeyInterface;
 
-    public function isBackupEligible(): bool;
-    public function isBackedUp(): bool;
-    public function isUvInitialized(): bool;
-    /** @return Enums\AuthenticatorTransport[] */
+    /**
+     * @internal
+     */
+    public function getSignCount(): int;
+
+    /**
+     * @api
+     *
+     * Returns an encoded version of the credential's id guaranteed to return
+     * no binary characters.
+     */
+    public function getStorageId(): string;
+
+    /**
+     * @internal
+     *
+     * @return Enums\AuthenticatorTransport[]
+     */
     public function getTransports(): array;
 
     /**
-     * Returns (optionally) an AttestationObject and the raw ClientDataJSON
-     * that was signed by that attestation. These are always used as a pair.
-     *
-     * @return ?array{Attestations\AttestationObjectInterface, BinaryString}
+     * @internal
      */
-    public function getAttestationData(): ?array;
+    public function isBackupEligible(): bool;
 
+    /**
+     * @internal
+     */
+    public function isBackedUp(): bool;
+
+    /**
+     * @internal
+     */
+    public function isUvInitialized(): bool;
 
     /**
      * @internal

--- a/src/CredentialV1.php
+++ b/src/CredentialV1.php
@@ -71,7 +71,7 @@ class CredentialV1 implements CredentialInterface
         return false;
     }
 
-    public function getAttestationData(): null
+    public function getAttestationData(): ?array
     {
         return null;
     }

--- a/src/CredentialV1.php
+++ b/src/CredentialV1.php
@@ -25,7 +25,6 @@ class CredentialV1 implements CredentialInterface
     ) {
     }
 
-    // FIXME: Move this to base64url
     public function getStorageId(): string
     {
         return bin2hex($this->id->unwrap());

--- a/src/CredentialV1.php
+++ b/src/CredentialV1.php
@@ -6,7 +6,8 @@ namespace Firehed\WebAuthn;
 
 /**
  * Data format for WebAuthn Level 2 formats which lacked data for backup
- * eligibility and did not track transports.
+ * eligibility and did not track transports. The numerous hardcoded return
+ * values are for the unsupported/untracked data.
  *
  * @internal
  */

--- a/src/CredentialV2.php
+++ b/src/CredentialV2.php
@@ -33,10 +33,9 @@ class CredentialV2 implements CredentialInterface
     ) {
     }
 
-    // FIXME: Move this to base64url
     public function getStorageId(): string
     {
-        return bin2hex($this->id->unwrap());
+        return $this->id->toBase64Url();
     }
 
     public function getSignCount(): int

--- a/src/CredentialV2.php
+++ b/src/CredentialV2.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Firehed\WebAuthn;
 
 /**
+ * @phpstan-type AttestationTuple array{
+ *   Attestations\AttestationObjectInterface,
+ *   BinaryString,
+ * }
+ *
  * @internal
  */
 class CredentialV2 implements CredentialInterface
@@ -17,6 +22,7 @@ class CredentialV2 implements CredentialInterface
     //     - counter bad
     /**
      * @param Enums\AuthenticatorTransport[] $transports
+     * @param ?AttestationTuple $attestation,
      */
     public function __construct(
         public readonly Enums\PublicKeyCredentialType $type,
@@ -27,9 +33,7 @@ class CredentialV2 implements CredentialInterface
         private readonly bool $isUvInitialized,
         private readonly bool $isBackupEligible,
         private readonly bool $isBackedUp,
-        // optional/required as a pair?
-        private readonly ?Attestations\AttestationObjectInterface $ao,
-        private readonly ?BinaryString $attestationCDJ,
+        private readonly ?array $attestation,
     ) {
     }
 
@@ -79,10 +83,9 @@ class CredentialV2 implements CredentialInterface
         return $this->isUvInitialized;
     }
 
-    public function getAttestationData(): array
+    public function getAttestationData(): ?array
     {
-        // if AO or CDJ are null, return null
-        return [$this->ao, $this->attestationCDJ];
+        return $this->attestation;
     }
 
     public function withUpdatedSignCount(int $newSignCount): CredentialInterface
@@ -96,8 +99,7 @@ class CredentialV2 implements CredentialInterface
             isUvInitialized: $this->isUvInitialized,
             isBackupEligible: $this->isBackupEligible,
             isBackedUp: $this->isBackedUp,
-            ao: $this->ao,
-            attestationCDJ: $this->attestationCDJ,
+            attestation: $this->attestation,
         );
     }
 }

--- a/tests/CredentialV1Test.php
+++ b/tests/CredentialV1Test.php
@@ -28,6 +28,12 @@ class CredentialV1Test extends \PHPUnit\Framework\TestCase
         // This test is flexible...storageId needs to be kept stable but the
         // pre-1.0 version could change before final release
         self::assertSame('ffff', $credential->getStorageId(), 'Storage ID wrong');
+
+        self::assertFalse($credential->isBackupEligible(), 'Backup tracking not in format');
+        self::assertFalse($credential->isBackedUp(), 'Backup tracking not in format');
+        self::assertFalse($credential->isUvInitialized(), 'UV tracking not in format');
+        self::assertSame([], $credential->getTransports(), 'Transport tracking not in format');
+        self::assertNull($credential->getAttestationData(), 'Attestation tracking not in format');
     }
 
     public function testUpdatingSignCount(): void

--- a/tests/CredentialV2Test.php
+++ b/tests/CredentialV2Test.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CredentialV2Test extends TestCase
 {
-    public function testAccessors(): void
+    public function testAccessors(): CredentialV2
     {
         $pk = self::createMock(PublicKey\PublicKeyInterface::class);
         $coseKey = self::createMock(COSEKey::class);
@@ -33,6 +33,7 @@ class CredentialV2Test extends TestCase
         );
 
         self::assertTrue(BinaryString::fromHex('B0BACAFE')->equals($credential->getId()), 'ID changed');
+        self::assertSame(10, $credential->getSignCount(), 'Sign count wrong');
         // Leaving out the COSEey CBOR for now...tat needs work!
         self::assertSame($pk, $credential->getPublicKey(), 'PubKey changed');
         // This test is flexible...storageId needs to be kept stable but the
@@ -46,5 +47,15 @@ class CredentialV2Test extends TestCase
             Enums\AuthenticatorTransport::Internal,
         ], $credential->getTransports(), 'Transports lost');
         self::assertNull($credential->getAttestationData(), 'Attestation was not provided');
+
+        return $credential;
+    }
+
+    /** @depends testAccessors */
+    public function testUpdateSignCount(CredentialV2 $credential): void
+    {
+        $updated = $credential->withUpdatedSignCount(11);
+        self::assertNotSame($credential, $updated, 'Should return new object');
+        self::assertSame(11, $updated->getSignCount(), 'Sign count did not update');
     }
 }

--- a/tests/CredentialV2Test.php
+++ b/tests/CredentialV2Test.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\WebAuthn;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Firehed\WebAuthn\CredentialV2
+ */
+class CredentialV2Test extends TestCase
+{
+    public function testAccessors(): void
+    {
+        $pk = self::createMock(PublicKey\PublicKeyInterface::class);
+        $coseKey = self::createMock(COSEKey::class);
+        $coseKey->method('getPublicKey')
+            ->willReturn($pk);
+        $credential = new CredentialV2(
+            type: Enums\PublicKeyCredentialType::PublicKey,
+            id: BinaryString::fromHex('B0BACAFE'),
+            coseKey: $coseKey,
+            signCount: 10,
+            transports: [
+                Enums\AuthenticatorTransport::Internal,
+            ],
+            isUvInitialized: true,
+            isBackupEligible: true,
+            isBackedUp: true,
+            attestation: null,
+        );
+
+        self::assertTrue(BinaryString::fromHex('B0BACAFE')->equals($credential->getId()), 'ID changed');
+        // Leaving out the COSEey CBOR for now...tat needs work!
+        self::assertSame($pk, $credential->getPublicKey(), 'PubKey changed');
+        // This test is flexible...storageId needs to be kept stable but the
+        // pre-1.0 version could change before final release
+        self::assertSame('sLrK_g', $credential->getStorageId(), 'Storage ID wrong');
+
+        self::assertTrue($credential->isBackupEligible(), 'Backup eligible lost');
+        self::assertTrue($credential->isBackedUp(), 'Backup state list');
+        self::assertTrue($credential->isUvInitialized(), 'UV state list');
+        self::assertEqualsCanonicalizing([
+            Enums\AuthenticatorTransport::Internal,
+        ], $credential->getTransports(), 'Transports lost');
+        self::assertNull($credential->getAttestationData(), 'Attestation was not provided');
+    }
+}


### PR DESCRIPTION
This adds additional methods to the credential interface for tracking the [complete set of recommended data](https://www.w3.org/TR/webauthn-3/#reg-ceremony-store-credential-record) in the updated spec (§7.1¶27).

This does NOT yet integrate the updated data into the storage tooling. As has been the trend recently, this is being pulled out of #53.