### PR TITLE
Support base64url access for challenges; adjust legacy credential format

### DIFF
--- a/src/Challenge.php
+++ b/src/Challenge.php
@@ -45,29 +45,14 @@ class Challenge implements ChallengeInterface
         return $this->wrapped;
     }
 
-    /**
-     * This produces a string that can be decoded with Javascript's `atob`
-     * function. The result of that will need to be further encoded into a
-     * BufferSource to be used in the `publicKey.challenge`; e.g. transformed
-     * into a `Uint8Array`:
-     *
-     * ```php
-     * header('Content-type: application/json');
-     * echo json_encode($challenge->getBase64());
-     * ```
-     *
-     * ```javascript
-     * const response = await fetch(request to above endpoint)
-     * const challengeB64 = await response.json()
-     * const challenge = atob(challengeB64)
-     * return Uint8Array.from(challenge, c => c.charCodeAt(0))
-     * ```
-     *
-     * @api
-     */
     public function getBase64(): string
     {
         return base64_encode($this->wrapped->unwrap());
+    }
+
+    public function getBase64Url(): string
+    {
+        return $this->wrapped->toBase64Url();
     }
 
     /**
@@ -83,8 +68,6 @@ class Challenge implements ChallengeInterface
      */
     public function __unserialize(array $serialized): void
     {
-        $bin = base64_decode($serialized['b64'], true);
-        assert($bin !== false);
-        $this->wrapped = new BinaryString($bin);
+        $this->wrapped = BinaryString::fromBase64($serialized['b64']);
     }
 }

--- a/src/ChallengeInterface.php
+++ b/src/ChallengeInterface.php
@@ -9,6 +9,23 @@ interface ChallengeInterface
     /**
      * @api
      *
+     * This produces a string that can be decoded with Javascript's `atob`
+     * function. The result of that will need to be further encoded into a
+     * BufferSource to be used in the `publicKey.challenge`; e.g. transformed
+     * into a `Uint8Array`:
+     *
+     * ```php
+     * header('Content-type: application/json');
+     * echo json_encode($challenge->getBase64());
+     * ```
+     *
+     * ```javascript
+     * const response = await fetch(request to above endpoint)
+     * const challengeB64 = await response.json()
+     * const challenge = atob(challengeB64)
+     * return Uint8Array.from(challenge, c => c.charCodeAt(0))
+     * ```
+     *
      * While this is not deprecated, it's recommended to instead use
      * getBase64Url instead as it's more consistent with WebAuthn native
      * formats.
@@ -17,6 +34,9 @@ interface ChallengeInterface
 
     /**
      * @api
+     *
+     * Same idea as getBase64() but (unsurprisingly) returns the base64url
+     * format variant. This is used in newer WebAuthn APIs natively.
      */
     public function getBase64Url(): string;
 

--- a/src/ChallengeInterface.php
+++ b/src/ChallengeInterface.php
@@ -8,8 +8,17 @@ interface ChallengeInterface
 {
     /**
      * @api
+     *
+     * While this is not deprecated, it's recommended to instead use
+     * getBase64Url instead as it's more consistent with WebAuthn native
+     * formats.
      */
     public function getBase64(): string;
+
+    /**
+     * @api
+     */
+    public function getBase64Url(): string;
 
     /**
      * @internal

--- a/src/CredentialV1.php
+++ b/src/CredentialV1.php
@@ -26,10 +26,9 @@ class CredentialV1 implements CredentialInterface
     ) {
     }
 
-    // FIXME: Move this to base64url
     public function getStorageId(): string
     {
-        return bin2hex($this->id->unwrap());
+        return $this->id->toBase64Url();
     }
 
     public function getSignCount(): int

--- a/src/ExpiringChallenge.php
+++ b/src/ExpiringChallenge.php
@@ -58,6 +58,14 @@ class ExpiringChallenge implements ChallengeInterface
         return $this->wrapped->getBase64();
     }
 
+    public function getBase64Url(): string
+    {
+        if ($this->isExpired()) {
+            throw new Errors\ExpiredChallengeError();
+        }
+        return $this->wrapped->getBase64Url();
+    }
+
     public function getBinary(): BinaryString
     {
         if ($this->isExpired()) {
@@ -89,9 +97,7 @@ class ExpiringChallenge implements ChallengeInterface
      */
     public function __unserialize(array $serialized): void
     {
-        $bin = base64_decode($serialized['c'], true);
-        assert($bin !== false);
-        $this->wrapped = new Challenge(new BinaryString($bin));
+        $this->wrapped = new Challenge(BinaryString::fromBase64($serialized['c']));
         $this->expiration = new DateTimeImmutable('@' . $serialized['e']);
     }
 }

--- a/tests/ChallengeInterfaceTestTrait.php
+++ b/tests/ChallengeInterfaceTestTrait.php
@@ -38,11 +38,18 @@ trait ChallengeInterfaceTestTrait
 
         $binary = $challenge->getBinary();
         $base64 = $challenge->getBase64();
+        $base64Url = $challenge->getBase64Url();
 
         self::assertSame(
             $base64,
             base64_encode($binary->unwrap()),
             'Base64 encoding the unwrapped binary did not match getBase64 result',
+        );
+
+        self::assertSame(
+            $base64Url,
+            $binary->toBase64Url(),
+            'Base64URL encoding was incorrect',
         );
     }
 

--- a/tests/CredentialV1Test.php
+++ b/tests/CredentialV1Test.php
@@ -16,18 +16,18 @@ class CredentialV1Test extends \PHPUnit\Framework\TestCase
         $coseKey->method('getPublicKey')
             ->willReturn($pk);
         $credential = new CredentialV1(
-            id: BinaryString::fromHex('FFFF'),
+            id: BinaryString::fromHex('B0BACAFE'),
             coseKey: $coseKey,
             signCount: 10,
         );
 
         self::assertSame(10, $credential->getSignCount(), 'Sign count wrong');
-        self::assertTrue(BinaryString::fromHex('FFFF')->equals($credential->getId()), 'ID changed');
+        self::assertTrue(BinaryString::fromHex('B0BACAFE')->equals($credential->getId()), 'ID changed');
         // Leaving out the COSEey CBOR for now...tat needs work!
         self::assertSame($pk, $credential->getPublicKey(), 'PubKey changed');
         // This test is flexible...storageId needs to be kept stable but the
         // pre-1.0 version could change before final release
-        self::assertSame('ffff', $credential->getStorageId(), 'Storage ID wrong');
+        self::assertSame('sLrK_g', $credential->getStorageId(), 'Storage ID wrong');
 
         self::assertFalse($credential->isBackupEligible(), 'Backup tracking not in format');
         self::assertFalse($credential->isBackedUp(), 'Backup tracking not in format');

--- a/tests/ExpiringChallengeTest.php
+++ b/tests/ExpiringChallengeTest.php
@@ -43,7 +43,6 @@ class ExpiringChallengeTest extends \PHPUnit\Framework\TestCase
         $_ = $ec->getBinary();
     }
 
-
     public function testPastExpirationThrowsWhenGettingBase64(): void
     {
         $interval = new DateInterval('PT2S');
@@ -52,6 +51,16 @@ class ExpiringChallengeTest extends \PHPUnit\Framework\TestCase
 
         self::expectException(Errors\ExpiredChallengeError::class);
         $ec->getBase64();
+    }
+
+    public function testPastExpirationThrowsWhenGettingBase64Url(): void
+    {
+        $interval = new DateInterval('PT2S');
+        $interval->invert = 1; // Negative
+        $ec = new ExpiringChallenge($interval);
+
+        self::expectException(Errors\ExpiredChallengeError::class);
+        $ec->getBase64Url();
     }
 
     public function testPastExpirationThrowsWhenGettingBinary(): void

--- a/tests/TestUtilities/TestVectorFixedChallenge.php
+++ b/tests/TestUtilities/TestVectorFixedChallenge.php
@@ -30,4 +30,9 @@ class TestVectorFixedChallenge implements ChallengeInterface
     {
         throw new Exception('Not for use during testing');
     }
+
+    public function getBase64Url(): string
+    {
+        throw new Exception('Not for use during testing');
+    }
 }


### PR DESCRIPTION
This reduces the need for RP servers to use internal methods by directly exposing the challenge as base64url, which is used by the (limited support) native formats as noted in #48 (a tool to produce the entire format will come as well!).

Additionally, this matches up the storage id formats for both credential formats, which as-is would not function as expected (new authorizations would return a v2, and subsequently could fail to find an existing matching v1 format depending on the lookup approach)

> [!WARNING]
> BC BREAK: this changes the storage identifier for the older credential format. This was noted in tests as a pre-1.0 possibility.

Fixes #59