### PR TITLE
Make codecov a bit more tolerant about diffs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,8 @@
 coverage:
   status:
+    patch:
+      default:
+        threshold: 10%
     project:
-      threshold: 5%
+      default:
+        threshold: 5%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project:
+      threshold: 5%


### PR DESCRIPTION
Codecov defaults to being extremely strict about coverage changes. Since some areas of the codebase are _extremely_ hard to test (e.g. various openssl functions returning false), some PRs are getting red-flagged unnecessarily. This aims to tone things down bit.