### PR TITLE
Provide bypass for not-yet-supported attestation formats

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,4 +79,4 @@ jobs:
 
       - name: Submit code coverage
         if: ${{ always() }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -692,8 +692,16 @@ Due to an inability to generate responses with all formats, not all are supporte
 | `apple` | ✅⚠️ [^ext-vec], [^limited-trust-path] | 8.8 | Apple no longer appears to use this format, instead providing non-attested credentials (fmt=none). |
 | `compound` | ❌ | 8.9 | This format only appears in the editor's draft of the spec and is not yet on the official registry. |
 
-If you receive an `UnhandledMatchError` from the library pertaining to a format, please file an issue.
+By default, the `$registration->verify()` process will reject uncertain trust paths.
+If you receive a `RegistratonError` from the library referencing `7.1.24` or `insufficient attestation trustworthiness`, it's due to this default.
+
+First, *please* file an issue containing the registration data you were attempting to use (the JSON over the network is fine; this contains no PII) - this will help improve the compatibility of the library.
+Then, if desired, you can pass `rejectUncertainTrustPaths: false` into the `verify()` arguments (this is easiest with named arguments).
+Doing so provides more flexibility in the registration process, at the expense of looser verification of credentials.
+
 The library aims to have full format coverage eventually, but _needs your help_ in order to get there.
+
+Complete support for trustworthiness rules is a tricky API to get right, so for now, this is the only escape-hatch!
 
 ## Resources and Errata
 

--- a/src/Attestations/AttestationObject.php
+++ b/src/Attestations/AttestationObject.php
@@ -51,10 +51,10 @@ class AttestationObject implements AttestationObjectInterface
     public function verify(BinaryString $clientDataHash): VerificationResult
     {
         $statement = match ($this->format) {
-            Format::Apple => new Apple($this->attStmt),
+            Format::Apple => new Apple($this->attStmt), // @phpstan-ignore-line
             Format::None => new None($this->attStmt),
-            Format::Packed => new Packed($this->attStmt),
-            Format::U2F => new FidoU2F($this->attStmt),
+            Format::Packed => new Packed($this->attStmt), // @phpstan-ignore-line
+            Format::U2F => new FidoU2F($this->attStmt), // @phpstan-ignore-line
             default => new LibraryUnsupported(),
         };
         return $statement->verify($this->data, $clientDataHash);

--- a/src/Attestations/AttestationObject.php
+++ b/src/Attestations/AttestationObject.php
@@ -55,7 +55,7 @@ class AttestationObject implements AttestationObjectInterface
             Format::None => new None($this->attStmt),
             Format::Packed => new Packed($this->attStmt),
             Format::U2F => new FidoU2F($this->attStmt),
-            default => new LibraryUnsupported($this->attStmt),
+            default => new LibraryUnsupported(),
         };
         return $statement->verify($this->data, $clientDataHash);
     }

--- a/src/Attestations/AttestationObject.php
+++ b/src/Attestations/AttestationObject.php
@@ -55,6 +55,7 @@ class AttestationObject implements AttestationObjectInterface
             Format::None => new None($this->attStmt),
             Format::Packed => new Packed($this->attStmt),
             Format::U2F => new FidoU2F($this->attStmt),
+            default => new LibraryUnsupported($this->attStmt),
         };
         return $statement->verify($this->data, $clientDataHash);
     }

--- a/src/Attestations/LibraryUnsupported.php
+++ b/src/Attestations/LibraryUnsupported.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\WebAuthn\Attestations;
+
+use Firehed\WebAuthn\AuthenticatorData;
+use Firehed\WebAuthn\BinaryString;
+
+class LibraryUnsupported implements AttestationStatementInterface
+{
+    /**
+     * @param mixed[] $data
+     */
+    public function __construct(private array $data)
+    {
+    }
+
+    public function verify(AuthenticatorData $data, BinaryString $clientDataHash): VerificationResult
+    {
+        return new VerificationResult(AttestationType::Uncertain);
+    }
+}

--- a/src/Attestations/LibraryUnsupported.php
+++ b/src/Attestations/LibraryUnsupported.php
@@ -9,13 +9,6 @@ use Firehed\WebAuthn\BinaryString;
 
 class LibraryUnsupported implements AttestationStatementInterface
 {
-    /**
-     * @param mixed[] $data
-     */
-    public function __construct(private array $data)
-    {
-    }
-
     public function verify(AuthenticatorData $data, BinaryString $clientDataHash): VerificationResult
     {
         return new VerificationResult(AttestationType::Uncertain);

--- a/src/CreateResponse.php
+++ b/src/CreateResponse.php
@@ -113,6 +113,7 @@ class CreateResponse implements Responses\AttestationInterface
         // 7.1.19
         // js options ~ publicKey.pubKeyCredParams[].alg
         // match $authData->ACD->alg (== ECDSA-SHA-256 = -7)
+        // This doesn't do much until supporting >1 algo
 
         // 7.1.20
         // TODO: clientExtensionResults / options.extensions

--- a/src/CreateResponse.php
+++ b/src/CreateResponse.php
@@ -43,6 +43,7 @@ class CreateResponse implements Responses\AttestationInterface
         ChallengeManagerInterface $challenge,
         RelyingPartyInterface $rp,
         Enums\UserVerificationRequirement $uv = Enums\UserVerificationRequirement::Preferred,
+        bool $rejectUncertainTrustPaths = true,
     ): CredentialInterface {
         // 7.1.1 - 7.1.3 are client code
         // 7.1.4 is temporarily skpped
@@ -143,12 +144,17 @@ class CreateResponse implements Responses\AttestationInterface
         //
         // here, it would be something like
         // ```php
-        $trustworthiness = match ($result->type) {
-            Attestations\AttestationType::None,
-            Attestations\AttestationType::Basic => null, // check if $rp permits this?
-            default => null, // openssl_x509_checkpurpose ?
-        };
+        // $trustworthiness = match ($result->type) {
+        //     Attestations\AttestationType::None,
+        //     Attestations\AttestationType::Basic => null, // check if $rp permits this?
+        //     default => null, // openssl_x509_checkpurpose ?
+        // };
         // ```
+        // For now, provide a crude escape-hatch. This will almost certainly
+        // change once all documented foramts are fully supported.
+        if ($result->type === Attestations\AttestationType::Uncertain && $rejectUncertainTrustPaths) {
+            $this->fail('7.1.24', 'Insufficient attestation trustworthiness');
+        }
 
         // 7.1.25
         if ($this->id->getLength() > 1023) {

--- a/src/CredentialInterface.php
+++ b/src/CredentialInterface.php
@@ -17,6 +17,12 @@ interface CredentialInterface
      *
      * @internal
      *
+     * A future public API may manifest as e.g. `reVerify()` which (if this
+     * data exists) would do something like:
+     * [$ao, $cdj] = getAttestationData()
+     * $hash = sha256(cdj)
+     * return $ao->verify($hash)
+     *
      * @return ?array{Attestations\AttestationObjectInterface, BinaryString}
      */
     public function getAttestationData(): ?array;

--- a/src/Responses/AttestationInterface.php
+++ b/src/Responses/AttestationInterface.php
@@ -29,5 +29,6 @@ interface AttestationInterface
         ChallengeManagerInterface $challenge,
         RelyingPartyInterface $rp,
         UserVerificationRequirement $uv = UserVerificationRequirement::Preferred,
+        bool $rejectUncertainTrustPaths = true,
     ): CredentialInterface;
 }

--- a/src/Responses/AttestationInterface.php
+++ b/src/Responses/AttestationInterface.php
@@ -20,6 +20,9 @@ use Firehed\WebAuthn\{
  */
 interface AttestationInterface
 {
+    // isBackupEligible: bool (7.1.17)
+    // isBackedUp: bool (7.1.18)
+    //
     public function isUserVerified(): bool;
 
     public function verify(

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -44,6 +44,7 @@ class IntegrationTest extends TestCase
         $cred = $createResponse->verify(
             $challengeManager,
             $rp,
+            rejectUncertainTrustPaths: false,
         );
 
         // More assertions to come!


### PR DESCRIPTION
By default, the library will require _any_ sort of "certain" trust path during credential registration - this is actually slightly stricter than the previous behavior, as `Packed` formats _can_ result in this path. To compensate (and as a bonus, ease library development), this provides a new flag that can be passed to the registration verification process that _permits_ these uncertain paths to go through.

In effect, if this flag is set, any credential has the security implications of the `none` format: you really know nothing about it, but authentication still is cryptographically verified. In the common case this means nothing, since (at minimum) Apple's implementation of passkeys uses `fmt: none` and blocking them is likely undesirable for most people.

Fixes #69.