### PR TITLE
Add expiration to challenge interface

### DIFF
--- a/src/Challenge.php
+++ b/src/Challenge.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\WebAuthn;
 
+use DateTimeImmutable;
+
 /**
  * The Challenge object has limited public-facing API:
  * - Create a challenge through the `::random()` method
@@ -55,7 +57,7 @@ class Challenge implements ChallengeInterface
         return $this->wrapped->toBase64Url();
     }
 
-    public function getExpiration(): null
+    public function getExpiration(): ?DateTimeImmutable
     {
         return null;
     }

--- a/src/Challenge.php
+++ b/src/Challenge.php
@@ -55,6 +55,11 @@ class Challenge implements ChallengeInterface
         return $this->wrapped->toBase64Url();
     }
 
+    public function getExpiration(): null
+    {
+        return null;
+    }
+
     /**
      * @return SerializationFormat
      */

--- a/src/ChallengeInterface.php
+++ b/src/ChallengeInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\WebAuthn;
 
+use DateTimeImmutable;
+
 interface ChallengeInterface
 {
     /**
@@ -44,4 +46,17 @@ interface ChallengeInterface
      * @internal
      */
     public function getBinary(): BinaryString;
+
+    /**
+     * If non-null, indicates when the challenge should be considered expired.
+     * This should be used in conjunction with request generation and align
+     * with the `timeout` used by `pkOptions`. Be aware that browsers may
+     * override the specified value; the current W3C recommendation (lv3) is
+     * between 5 and 10 minutes (300-600 seconds).
+     *
+     * At present, this is intended as a convenience for storage mechanisms and
+     * expected to be enforced by _ChallengeInterface_ implemetions, not the RP
+     * server and associated internals.
+     */
+    public function getExpiration(): ?DateTimeImmutable;
 }

--- a/src/ExpiringChallenge.php
+++ b/src/ExpiringChallenge.php
@@ -17,7 +17,7 @@ use InvalidArgumentException;
  *
  * @phpstan-type SerializationFormat array{
  *   c: string,
- *   e: int,
+ *   e: numeric-string,
  * }
  */
 class ExpiringChallenge implements ChallengeInterface
@@ -92,7 +92,7 @@ class ExpiringChallenge implements ChallengeInterface
     {
         return [
             'c' => $this->wrapped->getBase64(),
-            'e' => $this->expiration->getTimestamp(),
+            'e' => $this->expiration->format('U.u'),
         ];
     }
 

--- a/src/ExpiringChallenge.php
+++ b/src/ExpiringChallenge.php
@@ -74,6 +74,11 @@ class ExpiringChallenge implements ChallengeInterface
         return $this->wrapped->getBinary();
     }
 
+    public function getExpiration(): DateTimeImmutable
+    {
+        return DateTimeImmutable::createFromInterface($this->expiration);
+    }
+
     private function isExpired(): bool
     {
         $diff = $this->expiration->diff(new DateTimeImmutable());

--- a/src/ExpiringChallenge.php
+++ b/src/ExpiringChallenge.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\WebAuthn;
 
-use DateTimeInterface;
 use DateInterval;
 use DateTimeImmutable;
 use InvalidArgumentException;
@@ -24,7 +23,7 @@ use InvalidArgumentException;
 class ExpiringChallenge implements ChallengeInterface
 {
     private ChallengeInterface $wrapped;
-    private DateTimeInterface $expiration;
+    private DateTimeImmutable $expiration;
 
     /**
      * @internal
@@ -76,7 +75,7 @@ class ExpiringChallenge implements ChallengeInterface
 
     public function getExpiration(): DateTimeImmutable
     {
-        return DateTimeImmutable::createFromInterface($this->expiration);
+        return $this->expiration;
     }
 
     private function isExpired(): bool

--- a/tests/ChallengeInterfaceTestTrait.php
+++ b/tests/ChallengeInterfaceTestTrait.php
@@ -30,6 +30,11 @@ trait ChallengeInterfaceTestTrait
             $unserialized->getBase64(),
             'Base64 changed',
         );
+
+        self::assertEquals(
+            $challenge->getExpiration(),
+            $unserialized->getExpiration(),
+        );
     }
 
     public function testBinaryMatchesBase64(): void

--- a/tests/TestUtilities/TestVectorFixedChallenge.php
+++ b/tests/TestUtilities/TestVectorFixedChallenge.php
@@ -21,6 +21,11 @@ class TestVectorFixedChallenge implements ChallengeInterface
     {
     }
 
+    public function getExpiration(): null
+    {
+        return null;
+    }
+
     public function getBinary(): BinaryString
     {
         return BinaryString::fromBase64Url($this->b64u);

--- a/tests/TestUtilities/TestVectorFixedChallenge.php
+++ b/tests/TestUtilities/TestVectorFixedChallenge.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\WebAuthn\TestUtilities;
 
+use DateTimeImmutable;
 use Exception;
 use Firehed\WebAuthn\{
     BinaryString,
@@ -21,7 +22,7 @@ class TestVectorFixedChallenge implements ChallengeInterface
     {
     }
 
-    public function getExpiration(): null
+    public function getExpiration(): ?DateTimeImmutable
     {
         return null;
     }


### PR DESCRIPTION
For storage mechanisms where `serialize` would be inappropriate, this provides an alternate path to determining if and when a timestamp expires.

As of now, this is only a partial integration of the expiration logic - as noted in the interface, this is only for storage, not enforcement. The W3C spec is at best vague about challenge expiration, and really only covers the request timeout flags.