### PR TITLE
Replace manual concatenation with actual ASN.1 encoder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "ext-gmp": "*",
         "ext-hash": "*",
         "ext-openssl": "*",
-        "firehed/cbor": "^0.1.0"
+        "firehed/cbor": "^0.1.0",
+        "sop/asn1": "^4.1"
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^4.1",

--- a/src/COSE/Curve.php
+++ b/src/COSE/Curve.php
@@ -36,6 +36,8 @@ enum Curve: int
 
     case ED448 = 7; // OKP
 
+    // RFC 5480
+    // §2.1.1.1 OIDs for named curves
     public function getOid(): string
     {
         return match ($this) {


### PR DESCRIPTION
While on its own the current implementation is perfectly stable due to fixed lengths, adding support for other formats will become highly problematic. Instead, replace the ASN.1 handling with a suitable library.