### PR TITLE
Add limited support for RS256

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ There are additional notes in Best Practices / Data Handling around this.
 
 ## Supported Algorithms
 
-| Name | IANA ID | Supported | Notes |
+| Name | [IANA ID](https://www.iana.org/assignments/cose/cose.xhtml#algorithms) | Supported | Notes |
 | --- | --- | --- | --- |
 | ES256 | `-7` | ✅ | |
 | EdDSA | `-8` | ❌ | |

--- a/README.md
+++ b/README.md
@@ -680,6 +680,16 @@ If there are any unclear areas, please file an issue.
 
 There are additional notes in Best Practices / Data Handling around this.
 
+## Supported Algorithms
+
+| Name | IANA ID | Supported | Notes |
+| --- | --- | --- | --- |
+| ES256 | `-7` | ✅ | |
+| EdDSA | `-8` | ❌ | |
+| ES384 | `-35` | ❌ | [^alg-needs-tests] |
+| ES512 | `-36` | ❌ | [^alg-needs-tests] |
+| RS256 | `-257` | ✅⚠️ | [^ext-vec] |
+
 ## Supported Identifiers
 
 When generating a credential, the client will attest to its authenticity.
@@ -731,3 +741,4 @@ Intro to passkeys:
 
 [^ext-vec]: Support is based on [unofficial test vectors](https://github.com/w3c/webauthn/issues/1633).
 [^limited-trust-path]: Handling of attestation trust path is limited.
+[^alg-needs-tests]: This should be easy add support, but test vectors are needed

--- a/README.md
+++ b/README.md
@@ -684,11 +684,11 @@ There are additional notes in Best Practices / Data Handling around this.
 
 | Name | [IANA ID](https://www.iana.org/assignments/cose/cose.xhtml#algorithms) | Supported | Notes |
 | --- | --- | --- | --- |
-| ES256 | `-7` | ✅ | |
-| EdDSA | `-8` | ❌ | |
-| ES384 | `-35` | ❌ | [^alg-needs-tests] |
-| ES512 | `-36` | ❌ | [^alg-needs-tests] |
-| RS256 | `-257` | ✅⚠️ | [^ext-vec] |
+| `ES256` | `-7` | ✅ | |
+| `EdDSA` | `-8` | ❌ | |
+| `ES384` | `-35` | ❌ | [^alg-needs-tests] |
+| `ES512` | `-36` | ❌ | [^alg-needs-tests] |
+| `RS256` | `-257` | ✅⚠️ | [^ext-vec] |
 
 ## Supported Identifiers
 

--- a/src/COSE/Algorithm.php
+++ b/src/COSE/Algorithm.php
@@ -9,6 +9,9 @@ namespace Firehed\WebAuthn\COSE;
  * @see §2.1, table 1
  *
  * @link https://www.iana.org/assignments/cose/cose.xhtml#algorithms
+ *
+ * Any of these values SHOULD be safe to put in the publicKeyCredParams, but
+ * results may vary as not all combinations are thoroughly tested.
  */
 enum Algorithm: int
 {

--- a/src/COSE/Algorithm.php
+++ b/src/COSE/Algorithm.php
@@ -13,7 +13,9 @@ namespace Firehed\WebAuthn\COSE;
 enum Algorithm: int
 {
     case EcdsaSha256 = -7;
-    case EcdsaSha384 = -35;
-    case EcdsaSha512 = -36;
+    // case EcdsaSha384 = -35;
+    // case EcdsaSha512 = -36;
     // section 8.2: EdDSA = -8;
+
+    case Rs256 = -257;
 }

--- a/src/COSE/KeyType.php
+++ b/src/COSE/KeyType.php
@@ -12,9 +12,9 @@ namespace Firehed\WebAuthn\COSE;
  */
 enum KeyType: int
 {
-    case OctetKeyPair = 1;
+    // case OctetKeyPair = 1;
     case EllipticCurve = 2;
     case Rsa = 3;
-    case Symmetric = 4;
-    case Reserved = 0;
+    // case Symmetric = 4;
+    // case Reserved = 0;
 }

--- a/src/COSE/KeyType.php
+++ b/src/COSE/KeyType.php
@@ -14,6 +14,7 @@ enum KeyType: int
 {
     case OctetKeyPair = 1;
     case EllipticCurve = 2;
+    case Rsa = 3;
     case Symmetric = 4;
     case Reserved = 0;
 }

--- a/src/COSE/KeyType.php
+++ b/src/COSE/KeyType.php
@@ -12,9 +12,9 @@ namespace Firehed\WebAuthn\COSE;
  */
 enum KeyType: int
 {
+    // case Reserved = 0;
     // case OctetKeyPair = 1;
     case EllipticCurve = 2;
     case Rsa = 3;
     // case Symmetric = 4;
-    // case Reserved = 0;
 }

--- a/src/COSEKey.php
+++ b/src/COSEKey.php
@@ -20,11 +20,12 @@ use Firehed\CBOR\Decoder;
  * but re-inventing a wheel is very undesirable!).
  *
  * @see RFC 8152
- * @link https://www.rfc-editor.org/rfc/rfc8152.html
+ * @link https://www.rfc-editor.org/rfc/rfc8152
  *
- * @see RFC 8230 (RSA key support - not yet implemented)
+ * @see RFC 8230 (RSA keys)
+ * @link https://www.rfc-editor.org/rfc/rfc8230
  *
- * @see RFC 9052
+ * @see RFC 9052 (EC keys)
  * @link https://www.rfc-editor.org/rfc/rfc9052
  */
 class COSEKey
@@ -48,13 +49,12 @@ class COSEKey
 
         // Note: these limitations may be lifted in the future
         $keyType = COSE\KeyType::from($decodedCbor[self::INDEX_KEY_TYPE]);
-        // if ($keyType !== COSE\KeyType::EllipticCurve) {
-        //     throw new DomainException('Only EC2 keys supported');
-        // }
 
         $this->publicKey = match ($keyType) {
             COSE\KeyType::EllipticCurve => PublicKey\EllipticCurve::fromDecodedCbor($decodedCbor),
             COSE\KeyType::Rsa => PublicKey\RSA::fromDecodedCbor($decodedCbor),
+            // Other syntactially-valid key types exist, but the library
+            // doesn't handle them (yet?)
         };
 
         assert(array_key_exists(self::INDEX_ALGORITHM, $decodedCbor));

--- a/src/COSEKey.php
+++ b/src/COSEKey.php
@@ -54,7 +54,7 @@ class COSEKey
 
         $this->publicKey = match ($keyType) {
             COSE\KeyType::EllipticCurve => PublicKey\EllipticCurve::fromDecodedCbor($decodedCbor),
-            COSE\KeyType::RSA => PublicKey\RSA::fromDecodedCbor($decodedCbor),
+            COSE\KeyType::Rsa => PublicKey\RSA::fromDecodedCbor($decodedCbor),
         };
 
         assert(array_key_exists(self::INDEX_ALGORITHM, $decodedCbor));

--- a/src/COSEKey.php
+++ b/src/COSEKey.php
@@ -47,7 +47,7 @@ class COSEKey
         $decodedCbor = $decoder->decode($cbor->unwrap());
 
         // Note: these limitations may be lifted in the future
-        $keyType = COSE\KeyType::tryFrom($decodedCbor[self::INDEX_KEY_TYPE]);
+        $keyType = COSE\KeyType::from($decodedCbor[self::INDEX_KEY_TYPE]);
         // if ($keyType !== COSE\KeyType::EllipticCurve) {
         //     throw new DomainException('Only EC2 keys supported');
         // }

--- a/src/COSEKey.php
+++ b/src/COSEKey.php
@@ -48,12 +48,13 @@ class COSEKey
 
         // Note: these limitations may be lifted in the future
         $keyType = COSE\KeyType::tryFrom($decodedCbor[self::INDEX_KEY_TYPE]);
-        if ($keyType !== COSE\KeyType::EllipticCurve) {
-            throw new DomainException('Only EC2 keys supported');
-        }
+        // if ($keyType !== COSE\KeyType::EllipticCurve) {
+        //     throw new DomainException('Only EC2 keys supported');
+        // }
 
         $this->publicKey = match ($keyType) {
             COSE\KeyType::EllipticCurve => PublicKey\EllipticCurve::fromDecodedCbor($decodedCbor),
+            COSE\KeyType::RSA => PublicKey\RSA::fromDecodedCbor($decodedCbor),
         };
 
         assert(array_key_exists(self::INDEX_ALGORITHM, $decodedCbor));

--- a/src/PublicKey/RSA.php
+++ b/src/PublicKey/RSA.php
@@ -21,7 +21,7 @@ class RSA implements PublicKeyInterface
     private const INDEX_PUB_EXPONENT = -2;
     // Other values not relevant
 
-    private function __construct(
+    public function __construct(
         private BinaryString $n,
         private BinaryString $e,
     ) {
@@ -64,6 +64,9 @@ class RSA implements PublicKeyInterface
             // RFC 5280 §4.1.1.2 (AlgorithmIdentifier)
             new ASN\Constructed\Sequence(
                 new ASN\Primitive\ObjectIdentifier('1.2.840.113549.1.1.1'),
+                // This doesn't really matter for processing, but the PEM
+                // formatting checks don't align without it.
+                new ASN\Primitive\NullType(),
             ),
             // subjectPublicKey
             new ASN\Primitive\BitString($publicKey->toDER()),

--- a/src/PublicKey/RSA.php
+++ b/src/PublicKey/RSA.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\WebAuthn\PublicKey;
+
+use Firehed\WebAuthn\BinaryString;
+use Firehed\WebAuthn\COSE;
+use Firehed\WebAuthn\COSEKey;
+
+/**
+ * @internal
+ *
+ * @link https://www.rfc-editor.org/rfc/rfc8230.html
+ */
+class RSA implements PublicKeyInterface
+{
+    // RFC 8230 §4 table 4
+    private const INDEX_MODULUS = -1;
+    private const INDEX_PUB_EXPONENT = -2;
+    // Other values not relevant
+
+    private function __construct(
+        private BinaryString $n,
+        private BinaryString $e,
+    ) {
+        // print_r($this);
+    }
+
+
+
+    /**
+     * @param mixed[] $decoded
+     */
+    public static function fromDecodedCbor(array $decoded): RSA
+    {
+        // Checked upstream, but re-verify
+        assert(array_key_exists(COSEKey::INDEX_KEY_TYPE, $decoded));
+        $type = COSE\KeyType::from($decoded[COSEKey::INDEX_KEY_TYPE]);
+        assert($type === COSE\KeyType::Rsa);
+
+
+        assert(array_key_exists(COSEKey::INDEX_ALGORITHM, $decoded));
+        $algorithm = COSE\Algorithm::from($decoded[COSEKey::INDEX_ALGORITHM]);
+        // TODO: support other algorithms
+        if ($algorithm !== COSE\Algorithm::Rs256) {
+            throw new \DomainException('Only RS256 is supported');
+        }
+
+
+        assert(array_key_exists(self::INDEX_MODULUS, $decoded));
+        $n = new BinaryString($decoded[self::INDEX_MODULUS]);
+        assert(array_key_exists(self::INDEX_PUB_EXPONENT, $decoded));
+        $e = new BinaryString($decoded[self::INDEX_PUB_EXPONENT]);
+
+        return new RSA(
+            n: $n,
+            e: $e,
+        );
+    }
+
+    // https://www.identityblog.com/?p=389
+    public function getPemFormatted(): string
+    {
+        // Like EllipticCurve, lots of spooky ASN.1 magic.
+        $expEnc = self::asn1(0x02, $this->e->unwrap());
+        $modEnc = self::asn1(0x02, $this->n->unwrap());
+        $seqEnc = self::asn1(0x30, $modEnc . $expEnc);
+        $bitEnc = self::asn1(0x03, $seqEnc);
+        $algId = pack('H*', '300D06092A864886F70D0101010500');
+        // 30 0D // Sequence, legnth 13
+        //   06 09 // OID, length 9
+        //     2A 86 48 86 F7 0D 01 01 01 //  1.2.840.113549.1.1.1 (RSA)
+        //   05 00 // Null, length 0
+        $der = self::asn1(0x30, $algId . $bitEnc); // sequence, alg id and components
+
+        $pem  = "-----BEGIN PUBLIC KEY-----\n";
+        $pem .= chunk_split(base64_encode($der), 64, "\n");
+        $pem .= "-----END PUBLIC KEY-----";
+
+        // echo $pem;
+        return $pem;
+    }
+
+    private static function asn1(int $type, string $string): string
+    {
+        switch ($type) {
+            case 0x02: // integer
+                if (ord($string) > 0x7f) {
+                    $string = chr(0) . $string;
+                };
+                break;
+            case 0x03: // bit string
+                $string = chr(0) . $string;
+                break;
+        }
+        $length = strlen($string);
+        if ($length < 0x80) {
+            return sprintf('%c%c%s', $type, $length, $string);
+        } elseif ($length < 0x0100) {
+            return sprintf('%c%c%c%s', $type, 0x81, $length, $string);
+        } elseif ($length < 0x010000) {
+            return sprintf('%c%c%c%c%s', $type, 0x82, $length / 0x0100, $length % 0x0100, $string);
+        }
+        throw new \OverflowException('Cannot encode a value that big');
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -41,8 +41,6 @@ class IntegrationTest extends TestCase
         $createData = self::read($dir, 'reg-res');
         $createResponse = $jrp->parseCreateResponse($createData);
 
-        // var_dump($metadata);
-
         $cred = $createResponse->verify(
             $challengeManager,
             $rp,
@@ -90,7 +88,6 @@ class IntegrationTest extends TestCase
     {
         $request = self::read($dir, $file);
         assert(is_array($request['publicKey']));
-        // assert(($request['publicKey']['challenge'] ?? null) !== null);
         return new TestUtilities\TestVectorChallengeLoader($request['publicKey']['challenge']);
     }
 

--- a/tests/PublicKey/RSATest.php
+++ b/tests/PublicKey/RSATest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\WebAuthn\PublicKey;
+
+use Firehed\WebAuthn\BinaryString;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Firehed\WebAuthn\PublicKey\RSA
+ */
+class RSATest extends TestCase
+{
+    public function testPemEncodingOfKnownKey(): void
+    {
+        // This came from ...
+        // $ openssl genpkey -algorithm RSA -out private_key.pem
+        // $ openssl rsa -pubout -in private_key.pem -outform PEM -out public_key.pem
+        // $ openssl rsa -pubin -in public_key.pem -text
+        //
+        // Public-Key: (2048 bit)
+        // Modulus:
+        $openSslOut = <<<'HEX'
+        00:c3:04:9f:30:7d:05:90:3c:d6:52:27:3f:d2:4f:
+        f4:c7:27:66:9b:71:52:2e:a9:3f:1d:81:9e:ca:5f:
+        b2:36:56:2e:62:6f:76:18:70:5d:fe:59:c2:cc:5c:
+        d7:7e:95:99:89:d0:10:30:1e:1e:c2:26:36:6e:df:
+        b2:06:0a:32:db:fb:42:8e:6d:59:80:dd:98:33:3f:
+        62:58:5c:12:02:37:08:9f:23:67:60:e2:b2:4b:7b:
+        cd:18:78:0a:51:0c:83:3a:6e:8b:bb:5c:62:20:74:
+        aa:a7:a8:e3:4a:c7:20:b5:0d:f6:97:d1:3e:70:9e:
+        c7:7e:fa:60:49:7f:09:73:a1:ea:c6:0c:90:95:0d:
+        ee:c9:5b:18:0c:f5:15:00:14:4d:46:8d:7b:95:35:
+        34:92:09:4d:a3:28:b2:9e:b5:6b:46:d4:f7:77:a9:
+        a4:9e:3b:c5:a9:9f:d1:01:67:03:ba:ac:e9:bb:03:
+        2b:66:08:3a:63:74:2b:29:92:62:3c:b9:85:3e:94:
+        77:f3:a4:1e:88:78:4f:cf:e4:9f:de:51:98:8a:d2:
+        9d:5c:14:81:f3:30:3f:a2:e6:ab:60:b1:fc:d5:b8:
+        80:50:1f:83:e5:59:3c:f8:60:9a:9b:ba:72:93:75:
+        db:f8:63:1d:c9:ec:8b:a2:9d:f1:b7:5e:57:89:37:
+        4a:d7
+        HEX;
+        // Strip formatting
+        $hex = strtr($openSslOut, ["\n" => '', ':' => '']);
+        $modulus = BinaryString::fromHex($hex);
+
+        // Exponent: 65537 (0x10001)
+        $exponent = new BinaryString("\x01\x00\x01");
+
+        $rsa = new RSA($modulus, $exponent);
+        $pemOut = $rsa->getPemFormatted();
+
+        // (OpenSSL output)
+        $expected = <<<'PEM'
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwwSfMH0FkDzWUic/0k/0
+        xydmm3FSLqk/HYGeyl+yNlYuYm92GHBd/lnCzFzXfpWZidAQMB4ewiY2bt+yBgoy
+        2/tCjm1ZgN2YMz9iWFwSAjcInyNnYOKyS3vNGHgKUQyDOm6Lu1xiIHSqp6jjSscg
+        tQ32l9E+cJ7HfvpgSX8Jc6HqxgyQlQ3uyVsYDPUVABRNRo17lTU0kglNoyiynrVr
+        RtT3d6mknjvFqZ/RAWcDuqzpuwMrZgg6Y3QrKZJiPLmFPpR386QeiHhPz+Sf3lGY
+        itKdXBSB8zA/ouarYLH81biAUB+D5Vk8+GCam7pyk3Xb+GMdyeyLop3xt15XiTdK
+        1wIDAQAB
+        -----END PUBLIC KEY-----
+        PEM;
+
+        self::assertSame($expected, $pemOut);
+    }
+}

--- a/tests/integration/1633-firefox88-w10_windows-hello/auth-req.json
+++ b/tests/integration/1633-firefox88-w10_windows-hello/auth-req.json
@@ -1,0 +1,5 @@
+{
+    "publicKey": {
+        "challenge": "wpyKvM8cQ93PiYQfJSaMavJ6ngzem0IiTW83O2iHhf0"
+    }
+}

--- a/tests/integration/1633-firefox88-w10_windows-hello/auth-res.json
+++ b/tests/integration/1633-firefox88-w10_windows-hello/auth-res.json
@@ -1,0 +1,9 @@
+{
+    "rawId": "M5Vd4lSGSeR_vyhjTVDApu5ytb_GJWbIpCjIXDyF0tw",
+    "response": {
+        "authenticatorData": "KSqtX-Wo3JpWQpsrCGT2kSTRHZYWuoNy4MTSFTN75b0FAAAAAQ",
+        "signature": "xOQrl6C_R1FRrV3u1Dp-IMuFvbZVutB2hgK885GHVVQkpKcBeml4aQNLTkW3xaCSYCcEnK0PSO_8JaoSAJRpcW4Lff_WRjV0duoNBSju3BPdqbkasszFG7AeR7dbmMqVYPntrjpc4S_jQUbySSX-5WH7FCDGAxgZQgzvAterjRGewEk6VltI3vUrnR6TJJFWUoRa1a4uQyoXEWa7crBBRlhWdTAu0vEs9XuLECeoWoAcmk50NTQjgioVBPkeLH9nOyYdB3M6zrPX4TNWA2P9feftB58USdlEsfBe6II-JvrYUe8Wl0Lk17l70rv5C0n9nsdpjdVCtED8RUN_IuO84w",
+        "clientDataJSON": "eyJjaGFsbGVuZ2UiOiJ3cHlLdk04Y1E5M1BpWVFmSlNhTWF2SjZuZ3plbTBJaVRXODNPMmlIaGYwIiwiY2xpZW50RXh0ZW5zaW9ucyI6e30sImhhc2hBbGdvcml0aG0iOiJTSEEtMjU2Iiwib3JpZ2luIjoiaHR0cHM6Ly9tb2JpbGVwa2kub3JnIiwidHlwZSI6IndlYmF1dGhuLmdldCJ9"
+    },
+    "type": "public-key"
+}

--- a/tests/integration/1633-firefox88-w10_windows-hello/metadata.json
+++ b/tests/integration/1633-firefox88-w10_windows-hello/metadata.json
@@ -1,0 +1,4 @@
+{
+    "id": "M5Vd4lSGSeR_vyhjTVDApu5ytb_GJWbIpCjIXDyF0tw",
+    "origin": "https://mobilepki.org"
+}

--- a/tests/integration/1633-firefox88-w10_windows-hello/reg-req.json
+++ b/tests/integration/1633-firefox88-w10_windows-hello/reg-req.json
@@ -1,0 +1,5 @@
+{
+    "publicKey": {
+        "challenge": "NrDxtVXeUy5OPrhd5z2ztQX3aLw43MalyZIfqqlyX-o"
+    }
+}

--- a/tests/integration/1633-firefox88-w10_windows-hello/reg-res.json
+++ b/tests/integration/1633-firefox88-w10_windows-hello/reg-res.json
@@ -1,0 +1,11 @@
+{
+    "id": "M5Vd4lSGSeR_vyhjTVDApu5ytb_GJWbIpCjIXDyF0tw",
+    "rawId": "M5Vd4lSGSeR_vyhjTVDApu5ytb_GJWbIpCjIXDyF0tw",
+    "response": {
+        "clientDataJSON": "eyJjaGFsbGVuZ2UiOiJOckR4dFZYZVV5NU9QcmhkNXoyenRRWDNhTHc0M01hbHlaSWZxcWx5WC1vIiwiY2xpZW50RXh0ZW5zaW9ucyI6e30sImhhc2hBbGdvcml0aG0iOiJTSEEtMjU2Iiwib3JpZ2luIjoiaHR0cHM6Ly9tb2JpbGVwa2kub3JnIiwidHlwZSI6IndlYmF1dGhuLmNyZWF0ZSJ9",
+        "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVkBZykqrV_lqNyaVkKbKwhk9pEk0R2WFrqDcuDE0hUze-W9RQAAAAAImHBYytxLgbbhMN5Q3L6WACAzlV3iVIZJ5H-_KGNNUMCm7nK1v8YlZsikKMhcPIXS3KQBAwM5AQAgWQEA1us2fj4xCzDiXpCCGD7tvOMsxJ_6ahN07QdNVPZ04iHJvMIyTysmrj5PS5i1UwtaR6Z6MxnIrpjeN0NRfQ_h0U64xLQqUO6kKOlInquFnnZQRv3C9887ju4c7G8MhGt16l5ylSPnrkGPCbYxAjaxugniTM-G7jE4BGUlfnD_mgL5_P3KSnaXndK4rCIs7LV76dvX0MhBMPcRAgOsmcAt38GGOhDalFcwBzwnaLb9rQrRXkGBK8hDUYnRKF1jlIVMM9xakqprDKJ0HoiZ1gfcnn4VXlNj1RMjhbjXB9Jwf_vOs1J7IdG0WQXnZtKCL-3d_dD9RCe6XZIsocKX7KJ82yFDAQAB",
+        "transports": []
+    },
+    "type": "public-key",
+    "authenticatorAttachment": ""
+}


### PR DESCRIPTION
Adds support for RSA COSE key parsing and subsequent reformatting to PEM. For the most part, everything downstream Just Works since it implements the same `PublicKeyInterface` as `EllipticCurve`

In theory, this should work in all (legal) assertion paths. I'm less sure about attestation, so I'm indicating only partial support in the README. As the remaining attestation formats get supported, this should become extremely clear. Most formats don't really look at the public key in favor of the bundled certificate chain.