### PR TITLE
Conditional registration support

### DIFF
--- a/src/CreateResponse.php
+++ b/src/CreateResponse.php
@@ -44,6 +44,7 @@ class CreateResponse implements Responses\AttestationInterface
         RelyingPartyInterface $rp,
         Enums\UserVerificationRequirement $uv = Enums\UserVerificationRequirement::Preferred,
         bool $rejectUncertainTrustPaths = true,
+        Enums\CredentialMediationRequirement $mediation = Enums\CredentialMediationRequirement::Optional,
     ): CredentialInterface {
         // 7.1.1 - 7.1.3 are client code
         // 7.1.4 is temporarily skpped
@@ -93,7 +94,7 @@ class CreateResponse implements Responses\AttestationInterface
         }
 
         // 7.1.14
-        if (!$authData->isUserPresent()) {
+        if (!$authData->isUserPresent() && $mediation !== Enums\CredentialMediationRequirement::Conditional) {
             $this->fail('7.1.14', 'authData.isUserPresent');
         }
 

--- a/src/Enums/CredentialMediationRequirement.php
+++ b/src/Enums/CredentialMediationRequirement.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\WebAuthn\Enums;
+
+/**
+ * Credential Management (Level 1)
+ * §2.3.2
+ * @link https://w3c.github.io/webappsec-credential-management/#dom-credentialmediationrequirement-conditional
+ */
+enum CredentialMediationRequirement: string
+{
+    case Silent = 'silent';
+    case Optional = 'optional';
+    case Conditional = 'conditional';
+    case Required = 'required';
+}

--- a/tests/CreateResponseTest.php
+++ b/tests/CreateResponseTest.php
@@ -267,6 +267,12 @@ class CreateResponseTest extends \PHPUnit\Framework\TestCase
         self::markTestIncomplete();
     }
 
+    public function testUserNotPresentIsAllowedDuringConditionalRegistration(): void
+    {
+        // override authData
+        self::markTestIncomplete();
+    }
+
     // 7.1.15
     public function testUserVerifiedNotPresentWhenRequiredIsError(): void
     {


### PR DESCRIPTION
This adds a new optional parameter to the credential registration verification procedure (WebAuthn 7.1) to account for conditional mediation.

> Verify that the [UP](https://w3c.github.io/webauthn/#authdata-flags-up) bit of the [flags](https://w3c.github.io/webauthn/#authdata-flags) in authData is set, unless options.[mediation](https://w3c.github.io/webappsec-credential-management/#dom-credentialcreationoptions-mediation) is set to [conditional](https://w3c.github.io/webappsec-credential-management/#dom-credentialmediationrequirement-conditional).

Note that this is only in the draft spec, but it's likely to remain materially unchanged since this exact tooling was described at WWDC24. Still, I'm going to leave this undocumented for now (besides the actual method signature) in case anything changes before the next published version.

Fixes #83.