### PR TITLE
Add mediation requirement into create response parsing interface

### DIFF
--- a/src/Responses/AttestationInterface.php
+++ b/src/Responses/AttestationInterface.php
@@ -9,6 +9,7 @@ use Firehed\WebAuthn\{
     ChallengeLoaderInterface,
     CredentialInterface,
     RelyingPartyInterface,
+    Enums\CredentialMediationRequirement,
     Enums\UserVerificationRequirement,
 };
 
@@ -30,5 +31,6 @@ interface AttestationInterface
         RelyingPartyInterface $rp,
         UserVerificationRequirement $uv = UserVerificationRequirement::Preferred,
         bool $rejectUncertainTrustPaths = true,
+        CredentialMediationRequirement $mediation = CredentialMediationRequirement::Optional,
     ): CredentialInterface;
 }


### PR DESCRIPTION
This was omitted from #83. Adding it to the interface ensures that clients can actually use this without having to perform additional type checking.