### PR TITLE
Add 8.4 stable and 8.5-dev to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,8 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
-          - '8.4-dev'
+          - '8.4'
+          - '8.5-dev'
 
     steps:
       - name: Check out code

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "ext-hash": "*",
         "ext-openssl": "*",
         "firehed/cbor": "^0.1.0",
-        "sop/asn1": "^4.1"
+        "sop/asn1": "^4.1.2"
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         ],
         "autofix": "phpcbf",
         "phpunit": "phpunit",
-        "phpstan": "phpstan analyse",
+        "phpstan": "phpstan analyse --memory-limit=1G",
         "phpstan-baseline": "phpstan analyse --generate-baseline",
         "phpcs": "phpcs"
     }


### PR DESCRIPTION
PHP 8.4 was released last week, so this updates the test matrix accordingly. 8.1 can be reasonably dropped as well.

8.4 and 8.5 are now emitting a deprecation warning from the ASN.1 library. I intend to send a PR, but there's been no activity for quite some time (understandable given the context of the library, but there's also an open PR for other language-related improvements) so switching to a more actively-maintained library may end up being a better choice.