### PR TITLE
Replace GMP function calls with overloaded operators

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,6 @@ jobs:
         run: vendor/bin/phpunit
           --coverage-clover coverage.xml
           --coverage-text
-          --printer mheap\\GithubActionsReporter\\Printer
 
       - name: Submit code coverage
         if: ${{ always() }}

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -12,6 +12,7 @@ use Firehed\WebAuthn\Errors\VerificationError;
 use Sop\ASN1\Type as ASN;
 use UnexpectedValueException;
 
+use function gmp_cmp;
 use function gmp_import;
 
 /**
@@ -158,6 +159,8 @@ class EllipticCurve implements PublicKeyInterface
         $y2 = $y ** 2;
         $lhs = $y2 % $p;
 
-        return ($lhs - $rhs) === 0;
+        // Functionaly, `$lhs === $rhs` but avoids reference equality issues
+        // w/out having to introduce loose comparision ($lhs == $rhs works)
+        return 0 === gmp_cmp($lhs, $rhs);
     }
 }

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -156,11 +156,11 @@ class EllipticCurve implements PublicKeyInterface
 
         // This is only tested with P256 (secp256r1) but SHOULD be the same for
         // the other curves (none of which are supported yet)/
-        $x3 = gmp_pow($x, 3);
+        $x3 = $x ** 3;
         $ax = gmp_mul($a, $x);
         $rhs = gmp_mod(gmp_add($x3, gmp_add($ax, $b)), $p);
 
-        $y2 = gmp_pow($y, 2);
+        $y2 = $y ** 2;
         $lhs = gmp_mod($y2, $p);
 
         return 0 === gmp_cmp($lhs, $rhs); // Values match

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -152,11 +152,11 @@ class EllipticCurve implements PublicKeyInterface
 
         // This is only tested with P256 (secp256r1) but SHOULD be the same for
         // the other curves (none of which are supported yet)/
-        $x3 = $x ** 3;
-        $ax = $a * $x;
-        $rhs = ($x3 + $ax + $b) % $p;
+        $x3 = $x ** 3; // @phpstan-ignore binaryOp.invalid (phpstan/phpstan#12123)
+        $ax = $a * $x; // @phpstan-ignore binaryOp.invalid
+        $rhs = ($x3 + $ax + $b) % $p; // @phpstan-ignore binaryOp.invalid
 
-        $y2 = $y ** 2;
+        $y2 = $y ** 2; // @phpstan-ignore binaryOp.invalid
         $lhs = $y2 % $p;
 
         // Functionaly, `$lhs === $rhs` but avoids reference equality issues

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -157,8 +157,8 @@ class EllipticCurve implements PublicKeyInterface
         // This is only tested with P256 (secp256r1) but SHOULD be the same for
         // the other curves (none of which are supported yet)/
         $x3 = $x ** 3;
-        $ax = gmp_mul($a, $x);
-        $rhs = gmp_mod(gmp_add($x3, gmp_add($ax, $b)), $p);
+        $ax = $a * $x;
+        $rhs = gmp_mod($x3 + $ax + $b, $p);
 
         $y2 = $y ** 2;
         $lhs = gmp_mod($y2, $p);

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -12,12 +12,7 @@ use Firehed\WebAuthn\Errors\VerificationError;
 use Sop\ASN1\Type as ASN;
 use UnexpectedValueException;
 
-use function gmp_pow;
-use function gmp_add;
-use function gmp_cmp;
 use function gmp_import;
-use function gmp_mod;
-use function gmp_mul;
 
 /**
  * @internal

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -163,6 +163,6 @@ class EllipticCurve implements PublicKeyInterface
         $y2 = $y ** 2;
         $lhs = $y2 % $p;
 
-        return 0 === gmp_cmp($lhs, $rhs); // Values match
+        return ($lhs - $rhs) === 0;
     }
 }

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -158,10 +158,10 @@ class EllipticCurve implements PublicKeyInterface
         // the other curves (none of which are supported yet)/
         $x3 = $x ** 3;
         $ax = $a * $x;
-        $rhs = gmp_mod($x3 + $ax + $b, $p);
+        $rhs = ($x3 + $ax + $b) % $p;
 
         $y2 = $y ** 2;
-        $lhs = gmp_mod($y2, $p);
+        $lhs = $y2 % $p;
 
         return 0 === gmp_cmp($lhs, $rhs); // Values match
     }


### PR DESCRIPTION
Fixes #89 (though it really shouldn't).