### PR TITLE
Update to PHPStan 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,9 +51,9 @@
         "maglnet/composer-require-checker": "^4.1",
         "mheap/phpunit-github-actions-printer": "^1.5",
         "nikic/php-parser": "^4.14",
-        "phpstan/phpstan": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpstan/phpstan-strict-rules": "^1.0",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^9.6",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,283 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Cannot access offset ''credential'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: examples/functions.php
+
+		-
+			message: '#^Function getUserByName\(\) should return array\{id\: string, name\: string\}\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: examples/functions.php
+
+		-
+			message: '#^Parameter \#1 \$encoded of method Firehed\\WebAuthn\\Codecs\\Credential\:\:decode\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/functions.php
+
+		-
+			message: '#^Parameter \#2 \$name of function getUserByName expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/readmeLoginStep1.php
+
+		-
+			message: '#^Parameter \#2 \$userId of function getCredentialsForUserId expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/readmeLoginStep3.php
+
+		-
+			message: '#^Parameter \#2 \$username of function createUser expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/readmeRegisterStep1.php
+
+		-
+			message: '#^Parameter \#1 \$bytes of static method Firehed\\WebAuthn\\BinaryString\:\:fromBytes\(\) expects array\<int\>, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 8
+			path: src/ArrayBufferResponseParser.php
+
+		-
+			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(mixed\)\: mixed\)\|null, Closure\(int\|string\)\: \(Firehed\\WebAuthn\\Enums\\AuthenticatorTransport\|null\) given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ArrayBufferResponseParser.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_map expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ArrayBufferResponseParser.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/Apple.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/Apple.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/Apple.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/Apple.php
+
+		-
+			message: '#^Parameter \$haystack of function str_starts_with expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/Apple.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method Firehed\\WebAuthn\\Attestations\\Format\:\:from\(\) expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/AttestationObject.php
+
+		-
+			message: '#^Parameter \#1 \$wrapped of class Firehed\\WebAuthn\\BinaryString constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/AttestationObject.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/AttestationObject.php
+
+		-
+			message: '#^Property Firehed\\WebAuthn\\Attestations\\AttestationObject\:\:\$attStmt \(array\<mixed\>\) does not accept mixed\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/Attestations/AttestationObject.php
+
+		-
+			message: '#^Cannot access offset ''curve_oid'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Attestations/FidoU2F.php
+
+		-
+			message: '#^Cannot access offset ''1\.3\.6\.1\.4\.1\.45724\.1\.1\.4'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Attestations/Packed.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/Packed.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/Packed.php
+
+		-
+			message: '#^Parameter \#2 \$array of static method Firehed\\WebAuthn\\Attestations\\Packed\:\:requireKey\(\) expects array\<string, mixed\>, array given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/Attestations/Packed.php
+
+		-
+			message: '#^Parameter \#2 \$array of static method Firehed\\WebAuthn\\Attestations\\Packed\:\:requireKey\(\) expects array\<string, mixed\>, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 4
+			path: src/Attestations/Packed.php
+
+		-
+			message: '#^Parameter \$haystack of function str_starts_with expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Attestations/Packed.php
+
+		-
+			message: '#^Method Firehed\\WebAuthn\\BinaryString\:\:readUint16\(\) should return int but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/BinaryString.php
+
+		-
+			message: '#^Method Firehed\\WebAuthn\\BinaryString\:\:readUint32\(\) should return int but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/BinaryString.php
+
+		-
+			message: '#^Cannot access offset 1 on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/COSEKey.php
+
+		-
+			message: '#^Parameter \#1 \$decoded of static method Firehed\\WebAuthn\\PublicKey\\EllipticCurve\:\:fromDecodedCbor\(\) expects array\<mixed\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/COSEKey.php
+
+		-
+			message: '#^Parameter \#1 \$decoded of static method Firehed\\WebAuthn\\PublicKey\\RSA\:\:fromDecodedCbor\(\) expects array\<mixed\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/COSEKey.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method Firehed\\WebAuthn\\COSE\\Algorithm\:\:from\(\) expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/COSEKey.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method Firehed\\WebAuthn\\COSE\\KeyType\:\:from\(\) expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/COSEKey.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/COSEKey.php
+
+		-
+			message: '#^PHPDoc tag @api has invalid value \(\(with the above caveats\)\)\: Unexpected token "the", expected ''\)'' at offset 518 on line 11$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/ChallengeLoaderInterface.php
+
+		-
+			message: '#^Binary operation "\+" between \(array\|float\|int\) and GMP results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/PublicKey/EllipticCurve.php
+
+		-
+			message: '#^Binary operation "\+" between mixed and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/PublicKey/EllipticCurve.php
+
+		-
+			message: '#^Parameter \#1 \$num1 of function gmp_cmp expects GMP\|int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/PublicKey/EllipticCurve.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/PublicKey/EllipticCurve.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method Firehed\\WebAuthn\\COSE\\Algorithm\:\:from\(\) expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/PublicKey/EllipticCurve.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method Firehed\\WebAuthn\\COSE\\Curve\:\:from\(\) expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/PublicKey/EllipticCurve.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method Firehed\\WebAuthn\\COSE\\KeyType\:\:from\(\) expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/PublicKey/EllipticCurve.php
+
+		-
+			message: '#^Parameter \#1 \$wrapped of class Firehed\\WebAuthn\\BinaryString constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/PublicKey/EllipticCurve.php
+
+		-
+			message: '#^Parameter \#2 \$num2 of function gmp_cmp expects GMP\|int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/PublicKey/EllipticCurve.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method Firehed\\WebAuthn\\COSE\\Algorithm\:\:from\(\) expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/PublicKey/RSA.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method Firehed\\WebAuthn\\COSE\\KeyType\:\:from\(\) expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/PublicKey/RSA.php
+
+		-
+			message: '#^Parameter \#1 \$wrapped of class Firehed\\WebAuthn\\BinaryString constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/PublicKey/RSA.php
+
+		-
+			message: '#^Cannot access offset \(int\|string\) on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: tests/JsonResponseParserTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    # phpstan-baseline.neon
+    - phpstan-baseline.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
 parameters:

--- a/src/CreateResponse.php
+++ b/src/CreateResponse.php
@@ -6,6 +6,11 @@ namespace Firehed\WebAuthn;
 
 use UnexpectedValueException;
 
+use function array_key_exists;
+use function assert;
+use function is_array;
+use function is_string;
+
 /**
  * This is the internal representation of a PublicKeyCredential containing an
  * AuthenticatorAttestationResponse; i.e. the result of calling
@@ -63,6 +68,7 @@ class CreateResponse implements Responses\AttestationInterface
 
         // 7.1.8
         $cdjChallenge = $C['challenge'];
+        assert(is_string($cdjChallenge));
         $challenge = $challengeLoader->useFromClientDataJSON($cdjChallenge);
         if ($challenge === null) {
             $this->fail('7.1.8', 'C.challenge');
@@ -74,6 +80,7 @@ class CreateResponse implements Responses\AttestationInterface
         }
 
         // 7.1.9
+        assert(array_key_exists('origin', $C) && is_string($C['origin']));
         if (!$rp->matchesOrigin($C['origin'])) {
             $this->fail('7.1.9', 'C.origin');
         }

--- a/src/GetResponse.php
+++ b/src/GetResponse.php
@@ -6,6 +6,11 @@ namespace Firehed\WebAuthn;
 
 use UnexpectedValueException;
 
+use function array_key_exists;
+use function assert;
+use function is_array;
+use function is_string;
+
 /**
  * This is the internal representation of a PublicKeyCredential containing an
  * AuthenticatorAssertionResponse; i.e. the result of calling
@@ -108,6 +113,7 @@ class GetResponse implements Responses\AssertionInterface
 
         // 7.2.13
         $cdjChallenge = $C['challenge'];
+        assert(is_string($cdjChallenge));
         $challenge = $challengeLoader->useFromClientDataJSON($cdjChallenge);
         if ($challenge === null) {
             $this->fail('7.2.12', 'C.challenge');
@@ -119,6 +125,7 @@ class GetResponse implements Responses\AssertionInterface
         }
 
         // 7.2.14
+        assert(array_key_exists('origin', $C) && is_string($C['origin']));
         if (!$rp->matchesOrigin($C['origin'])) {
             $this->fail('7.2.13', 'C.origin');
         }

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -157,7 +157,7 @@ class EllipticCurve implements PublicKeyInterface
         $rhs = ($x3 + $ax + $b) % $p; // @phpstan-ignore binaryOp.invalid
 
         $y2 = $y ** 2; // @phpstan-ignore binaryOp.invalid
-        $lhs = $y2 % $p;
+        $lhs = $y2 % $p; // @phpstan-ignore binaryOp.invalid
 
         // Functionaly, `$lhs === $rhs` but avoids reference equality issues
         // w/out having to introduce loose comparision ($lhs == $rhs works)

--- a/src/SessionChallengeManager.php
+++ b/src/SessionChallengeManager.php
@@ -35,6 +35,7 @@ class SessionChallengeManager implements ChallengeManagerInterface
         }
         $challenge = $_SESSION[self::SESSION_KEY];
         unset($_SESSION[self::SESSION_KEY]);
+        assert($challenge instanceof ChallengeInterface);
         // Validate that the stored challenge matches the CDJ value
         if ($challenge->getBase64Url() === $base64Url) {
             return $challenge;

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -103,6 +103,7 @@ class IntegrationTest extends TestCase
     {
         $request = self::read($dir, $file);
         assert(is_array($request['publicKey']));
+        assert(is_string($request['publicKey']['challenge']));
         return new TestUtilities\TestVectorChallengeLoader($request['publicKey']['challenge']);
     }
 

--- a/tests/MultiOriginRelyingPartyTest.php
+++ b/tests/MultiOriginRelyingPartyTest.php
@@ -64,7 +64,7 @@ class MultiOriginRelyingPartyTest extends \PHPUnit\Framework\TestCase
      */
     public static function rpIdVectors(): array
     {
-        $mbs = fn ($domainString) => new BinaryString(hash('sha256', $domainString, true));
+        $mbs = fn (string $domainString) => new BinaryString(hash('sha256', $domainString, true));
         return [
             'domain match' => [$mbs('example.com'), true],
             'subdomain match' => [$mbs('www.example.com'), false],

--- a/tests/SingleOriginRelyingPartyTest.php
+++ b/tests/SingleOriginRelyingPartyTest.php
@@ -37,7 +37,7 @@ class SingleOriginRelyingPartyTest extends \PHPUnit\Framework\TestCase
      */
     public static function rpIdHashVectors(): array
     {
-        $mbs = fn ($domainString) => new BinaryString(hash('sha256', $domainString, true));
+        $mbs = fn (string $domainString) => new BinaryString(hash('sha256', $domainString, true));
         return [
             'localhost match' => ['http://localhost:3000', $mbs('localhost'), true],
             'domain match' => ['https://example.com', $mbs('example.com'), true],

--- a/tests/WildcardRelyingPartyTest.php
+++ b/tests/WildcardRelyingPartyTest.php
@@ -64,7 +64,7 @@ class WildcardRelyingPartyTest extends \PHPUnit\Framework\TestCase
      */
     public static function rpIdVectors(): array
     {
-        $mbs = fn ($domainString) => new BinaryString(hash('sha256', $domainString, true));
+        $mbs = fn (string $domainString) => new BinaryString(hash('sha256', $domainString, true));
         return [
             'domain match' => [$mbs('example.com'), true],
             'subdomain match' => [$mbs('www.example.com'), false],


### PR DESCRIPTION
This fixes a few type risks along the way, and adds some of the remaining into the baseline. The majority of those added to the baseline are more-or-less expected errors around input validation where badly formatted input is _expected_ to error or throw.