### PR TITLE
Move composer-require-checker to CI installation

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
+        with:
+          tools: composer-require-checker
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -79,4 +81,4 @@ jobs:
           --prefer-dist
 
       - name: Composer require-checker
-        run: vendor/bin/composer-require-checker check
+        run: composer-require-checker check

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
         "sop/asn1": "^4.1.2"
     },
     "require-dev": {
-        "maglnet/composer-require-checker": "^4.16",
         "mheap/phpunit-github-actions-printer": "^1.5",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",


### PR DESCRIPTION
This should avoid conflicts with the php-parser in updated package and platform versions.