### PR TITLE
Update PHPStan, remove outdated GMP warning suppression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "mheap/phpunit-github-actions-printer": "^1.5",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "^2.1.50",
         "phpunit/phpunit": "^11",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -152,13 +152,13 @@ class EllipticCurve implements PublicKeyInterface
 
         // This is only tested with P256 (secp256r1) but SHOULD be the same for
         // the other curves (none of which are supported yet)/
-        $x3 = $x ** 3; // @phpstan-ignore pow.leftNonNumeric, binaryOp.invalid (phpstan/phpstan#14288)
+        $x3 = $x ** 3; // @phpstan-ignore pow.leftNonNumeric (phpstan/phpstan#14288)
         $ax = $a * $x; // @phpstan-ignore mul.leftNonNumeric, mul.rightNonNumeric (phpstan/phpstan#14288)
-        // @phpstan-ignore plus.rightNonNumeric, mod.rightNonNumeric, binaryOp.invalid (phpstan/phpstan#14288)
+        // @phpstan-ignore plus.leftNonNumeric, plus.leftNonNumeric, plus.rightNonNumeric, plus.rightNonNumeric, mod.leftNonNumeric, mod.rightNonNumeric (phpstan/phpstan#14288)
         $rhs = ($x3 + $ax + $b) % $p;
 
-        $y2 = $y ** 2; // @phpstan-ignore pow.leftNonNumeric, binaryOp.invalid (phpstan/phpstan#14288)
-        $lhs = $y2 % $p; // @phpstan-ignore mod.rightNonNumeric, binaryOp.invalid (phpstan/phpstan#14288)
+        $y2 = $y ** 2; // @phpstan-ignore pow.leftNonNumeric (phpstan/phpstan#14288)
+        $lhs = $y2 % $p; // @phpstan-ignore mod.leftNonNumeric, mod.rightNonNumeric (phpstan/phpstan#14288)
 
         // Functionaly, `$lhs === $rhs` but avoids reference equality issues
         // w/out having to introduce loose comparision ($lhs == $rhs works)

--- a/src/PublicKey/EllipticCurve.php
+++ b/src/PublicKey/EllipticCurve.php
@@ -154,8 +154,11 @@ class EllipticCurve implements PublicKeyInterface
         // the other curves (none of which are supported yet)/
         $x3 = $x ** 3; // @phpstan-ignore pow.leftNonNumeric (phpstan/phpstan#14288)
         $ax = $a * $x; // @phpstan-ignore mul.leftNonNumeric, mul.rightNonNumeric (phpstan/phpstan#14288)
+        // phpcs:disable
+        // (need the long line for PHPStan to parse)
         // @phpstan-ignore plus.leftNonNumeric, plus.leftNonNumeric, plus.rightNonNumeric, plus.rightNonNumeric, mod.leftNonNumeric, mod.rightNonNumeric (phpstan/phpstan#14288)
         $rhs = ($x3 + $ax + $b) % $p;
+        // phpcs:enable
 
         $y2 = $y ** 2; // @phpstan-ignore pow.leftNonNumeric (phpstan/phpstan#14288)
         $lhs = $y2 % $p; // @phpstan-ignore mod.leftNonNumeric, mod.rightNonNumeric (phpstan/phpstan#14288)


### PR DESCRIPTION
PHPStan (though not strict rules) now accepts GMP overloaded math without complaining. This pulls in the version that adds support and adjusts the local error suppression to account for the change,